### PR TITLE
chore: localhost https 적용 및 사용자 운영체제마다 다르게 mkcert 설치하는 방법 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,7 @@ dist-ssr
 *.sln
 *.sw?
 
-
 *storybook.log
+
+# https
+*.pem

--- a/init-https.sh
+++ b/init-https.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# 운영체제 감지
+OS=$(uname)
+
+if [ "$OS" == "Darwin" ]; then
+    # MacOS인 경우
+    MKCERT_INSTALLED=$(which mkcert)
+
+    if [ -z "$MKCERT_INSTALLED" ]; then
+        echo "mkcert가 설치되어 있지 않습니다. brew로 mkcert를 설치합니다."
+        brew install mkcert
+    fi
+elif [ "$OS" == "MINGW64_NT" ] || [ "$OS" == "MINGW32_NT" ] || [ "$OS" == "CYGWIN_NT" ]; then
+    # Windows인 경우
+    MKCERT_INSTALLED=$(where mkcert)
+
+    if [ -z "$MKCERT_INSTALLED" ]; then
+        echo "mkcert가 설치되어 있지 않습니다. choco로 mkcert를 설치합니다."
+        choco install mkcert -y
+    fi
+else
+    echo "지원되지 않는 운영체제입니다."
+    exit 1
+fi
+
+# mkcert 설정 및 localhost 인증서 생성
+mkcert -install
+mkcert localhost
+
+# mkcert 설치 자동화
+# 1. mkcert 설치 여부를 확인하고 설치 안되어 있으면 brew로 mkcert를 설치(MacOS 기준 작성)
+# 2. mkcert -install 실행
+# 3. mkvert localhost 실행

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "init-https": "sh init-https.sh"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+    "routes": [
+      { "handle": "filesystem" },
+      { "src": "/.*", "dest": "/index.html" }
+    ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
-
+import fs from "fs";
 
 // https://vitejs.dev/config/
 export default defineConfig(({mode}) => {
@@ -50,6 +50,10 @@ export default defineConfig(({mode}) => {
           target: env.VITE_API_URL,
           changeOrigin: true,
         },
+      },
+      https: {
+        key: fs.readFileSync(path.resolve(__dirname, "localhost-key.pem")),
+        cert: fs.readFileSync(path.resolve(__dirname, "localhost.pem")),
       },
     },
   };


### PR DESCRIPTION
…받고 npm run init-https 실행 후 원래 하던대로 npm run dev해서 https 적용되는지 확인 바람

## #️⃣연관된 이슈

> close #10 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

> - localhost https 적용 및 사용자 운영체제마다 다르게 mkcert 설치하는 방법 설정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 1. clone이나 pull 받고 npm install 실행, root 경로에 init-https.sh 파일 있는지 확인 
> 2. npm run init-https 실행
> 3. root 경로에 .pem 이라는 파일 2개가 생성되었는지 확인
> 4. npm run dev해서 https 적용되는지 확인 
