### PR TITLE
fix : 이메일 전송 api request params -> body로 변경

### DIFF
--- a/src/api/user/postEmailVerification.ts
+++ b/src/api/user/postEmailVerification.ts
@@ -2,13 +2,17 @@ import api from "@api/fetcher";
 import apiRoutes from "@api/apiRoutes";
 import { useMutation } from "@tanstack/react-query";
 
-async function postEmailVerification(email: string): Promise<IResponseType> {
-  const endpoint = `${apiRoutes.users}/email-verification/sends?email=${email}`;
-  return await api.post({ endpoint });
+interface IemailBody {
+  email: string;
+}
+
+async function postEmailVerification(body: IemailBody): Promise<IResponseType> {
+  const endpoint = `${apiRoutes.users}/email-verification/sends`;
+  return await api.post({ endpoint, body });
 }
 
 export const usePostEmailVerification = () => {
   return useMutation({
-    mutationFn: (email: string) => postEmailVerification(email),
+    mutationFn: (data: IemailBody) => postEmailVerification(data),
   });
 };

--- a/src/pages/RegisterPage/page/index.tsx
+++ b/src/pages/RegisterPage/page/index.tsx
@@ -81,14 +81,17 @@ const RegisterPage: React.FC = () => {
 
   const handleSendCode = (email: string) => {
     setIsSendingEmailCode(true);
-    sendCode(email, {
-      onSuccess: () => {
-        alert("인증코드 발송 성공");
+    sendCode(
+      { email },
+      {
+        onSuccess: () => {
+          alert("인증코드 발송 성공");
+        },
+        onError: (error) => {
+          alert(error.message);
+        },
       },
-      onError: (error) => {
-        alert(error.message);
-      },
-    });
+    );
   };
 
   const handleCheckPasswordMatch = (confirmPassword: string, password: string) => {
@@ -178,6 +181,7 @@ const RegisterPage: React.FC = () => {
     inputList.push({
       name: "code",
       text: "인증코드 6자리 입력",
+      buttonText: "확인",
       type: "text",
       rules: {
         required: "Code is required",


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #43 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

> 이메일 인증 코드 전송 api, 인증코드 확인 api 
파라미터 -> 바디 로 수정

## 📝수정 내용(선택)
> -

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> - ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
