### PR TITLE
Hotfix: CalenderHeader props에 따른 아이콘 보여주는 로직 수정 및 타 헤더 수정

### DIFF
--- a/src/assets/Icons/headers/miniCalender.svg
+++ b/src/assets/Icons/headers/miniCalender.svg
@@ -1,4 +1,4 @@
 <svg width="28" height="26" viewBox="0 0 28 26" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="27.7333" height="25.4502" fill="white"/>
+<rect width="27.7333" height="25.4502" fill="none"/>
 <path d="M18.4889 2.12085V6.36256M9.24445 2.12085V6.36256M3.46667 10.6043H24.2667M5.77779 4.2417H21.9556C23.232 4.2417 24.2667 5.19124 24.2667 6.36256V21.2085C24.2667 22.3798 23.232 23.3294 21.9556 23.3294H5.77779C4.50139 23.3294 3.46667 22.3798 3.46667 21.2085V6.36256C3.46667 5.19124 4.50139 4.2417 5.77779 4.2417Z" stroke="#0B0B0B" stroke-opacity="0.9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/components/headers/CalenderHeader.tsx
+++ b/src/components/headers/CalenderHeader.tsx
@@ -2,26 +2,28 @@ import React from "react";
 import styles from "./calenderHeader.module.scss";
 import BackArrow2_Icon from "@assets/Icons/headers/backArrow2.svg?react";
 import MiniCalender_Icon from "@assets/Icons/headers/miniCalender.svg?react";
-// import More_Icon from "@assets/Icons/headers/moreIcon.svg?react";
 
 interface Props {
   title: "그룹 달력" | "나의 달력" | string;
+  type: "my" | "group";
   handleBackArrowClick: () => void;
   handleMiniCalenderClick: () => void;
-  // handleMoreIconClick?: () => void;
 }
 
 const CalenderHeader: React.FC<Props> = ({
   handleMiniCalenderClick,
-  // handleMoreIconClick,
   handleBackArrowClick,
   title,
+  type,
 }) => {
   return (
     <div className={styles.mainContainer}>
-      <div className={styles.leftSection} onClick={handleBackArrowClick}>
-        <BackArrow2_Icon width={9} height={18} />
-      </div>
+      {type === "group" && (
+        <div className={styles.leftSection} onClick={handleBackArrowClick}>
+          <BackArrow2_Icon width={9} height={18} />
+        </div>
+      )}
+
       <div className={styles.titleSection}>{title}</div>
       <div className={styles.rightSection}>
         <MiniCalender_Icon
@@ -30,7 +32,6 @@ const CalenderHeader: React.FC<Props> = ({
           onClick={handleMiniCalenderClick}
           className={styles.miniCalenderIconSection}
         />
-        {/* {title === "그룹 달력" && <More_Icon width={20} height={26} onClick={handleMoreIconClick} className={styles.moreIconSection} />} */}
       </div>
     </div>
   );

--- a/src/components/headers/HasOnlyRightIconHeader.tsx
+++ b/src/components/headers/HasOnlyRightIconHeader.tsx
@@ -4,10 +4,11 @@ import StarIcon from "@components/iconComponent/StarIcon";
 import RedDot_Icon from "@assets/Icons/headers/redDot.svg?react";
 import Alert_Icon from "@assets/Icons/headers/alertIcon.svg?react";
 import X_Icon from "@assets/Icons/headers/xIcon.svg?react"
+import MiniCalender_Icon from "@assets/Icons/headers/miniCalender.svg?react";
 
 interface Props {
   title: "PlanU" | string;
-  rightType: "alert" | "star" | "x";
+  rightType: "alert" | "star" | "x" | "calender";
   handleClick: () => void;
   isExistNoReadAlarms?: boolean;
   isBookmark?: boolean;
@@ -33,7 +34,7 @@ const HasOnlyRightIconHeader: React.FC<Props> = ({
           </div>
         ) : rightType === "star" ? (
           <StarIcon isBookmark={isBookmark} id={groupId} handleClick={handleClick} />
-        ) : <X_Icon width={24} height={24}/>}
+        ) : rightType === "x" ? <X_Icon width={24} height={24}/> : <MiniCalender_Icon />}
       </div>
     </div>
   );

--- a/src/components/headers/Headers.stories.tsx
+++ b/src/components/headers/Headers.stories.tsx
@@ -52,6 +52,12 @@ function Headers() {
             }}
           />
           <HasOnlyBackArrowHeader
+            title="가능한 날짜 보기"
+            handleClick={() => {
+              return;
+            }}
+          />
+          <HasOnlyBackArrowHeader
             title="프로필 수정"
             handleClick={() => {
               return;
@@ -95,6 +101,7 @@ function Headers() {
         <div className={styles.Container}>
           <CalenderHeader
             title="그룹 달력"
+            type="group"
             handleBackArrowClick={() => {
               return;
             }}
@@ -104,6 +111,7 @@ function Headers() {
           />
           <CalenderHeader
             title="나의 달력"
+            type="my"
             handleBackArrowClick={() => {
               return;
             }}
@@ -253,6 +261,13 @@ function Headers() {
               return;
             }}
           />
+          <HasOnlyRightIconHeader
+            title="가능한 날짜 보기"
+            rightType="calender"
+            handleClick={() => {
+              return;
+            }}
+          />
         </div>
       </div>
 
@@ -261,6 +276,7 @@ function Headers() {
         <div className={styles.Container}>
           <OnlyTextHeader title="가입 완료" backgroundColor="purple" />
           <OnlyTextHeader title="마이페이지" backgroundColor="white" />
+          <OnlyTextHeader title="가능한 날짜 보기" backgroundColor="purple" />
         </div>
       </div>
     </div>

--- a/src/components/headers/calenderHeader.module.scss
+++ b/src/components/headers/calenderHeader.module.scss
@@ -1,6 +1,5 @@
 .mainContainer {
   display: flex;
-  justify-content: space-between;
   align-items: center;
   width: 100%;
   height: 56px;
@@ -12,14 +11,21 @@
   top: 0;
   .leftSection {
     cursor: pointer;
+    justify-content: start;
+    width: 100%;
   }
   .titleSection {
     font-size: 20px;
     color: var(--black);
     font-weight: bold;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
   }
   .rightSection {
     display: flex;
+    width: 100%;
+    justify-content: end;
     align-items: center;
     flex-direction: row;
     gap: 5px;

--- a/src/components/headers/hasOnlyRightIconHeader.module.scss
+++ b/src/components/headers/hasOnlyRightIconHeader.module.scss
@@ -22,6 +22,7 @@
   }
   .rightSection {
     cursor: pointer;
+    position: relative;
 
     .redDotIcon {
       position: absolute;


### PR DESCRIPTION
## #️⃣연관된 이슈

>  close #48 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

> 1. 오른쪽 아이콘만 있는 헤더 rightType에 calender 추가
> 2. 캘린더 헤더 props에 type("my","group") 추가

## 📝수정 내용(선택)
> 1. /icons/header/miniCalender.svg 배경색 none으로 수정
> 2. 캘린더 헤더 props에 type("my","group") 추가에 따른 아이콘 보여주는 로직 수정 및 스타일 수정
> 3. 헤더 스토리북 로직 수정

### 스크린샷 (선택)
<img width="466" alt="스크린샷 2024-12-03 오후 5 21 31" src="https://github.com/user-attachments/assets/43b37d0b-b0e0-4bcf-82e8-f3e6a2cead86">
<img width="469" alt="스크린샷 2024-12-03 오후 5 21 51" src="https://github.com/user-attachments/assets/35ed6224-7b8e-4e82-b339-733c765cdd11">
<img width="458" alt="스크린샷 2024-12-03 오후 5 17 03" src="https://github.com/user-attachments/assets/049f7201-4039-4e61-b4de-56ba2f35a206">
<img width="481" alt="스크린샷 2024-12-03 오후 5 22 18" src="https://github.com/user-attachments/assets/2d740f65-ecb1-4452-8e1a-a1ded25e4d56">


## 💬리뷰 요구사항(선택)
> - 피그마 나의 달력, 그룹 달력 항목에 나오는 헤더들만 수정했습니다. 해당 페이지 작업할때 참고해주세요
> - 나의 달력, 그룹 달력 : CalenderHeader.tsx
> - 나의 달력 / 가능한 날짜 보기 : HasOnlyRightIconHeader.tsx
> - 나의 달력 / 가능한 날짜 선택 : OnlyTextHeader.tsx
> - 그룹 달력 / 가능한 날짜 보기 : HasOnlyBackArrowHeader.tsx

