### PR TITLE
Feat: 로그인 상태에 따른 페이지 리디렉션 작업 및 누락된 페이지 추가, 라우팅 재설정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,60 +12,77 @@ import GroupCalendarPage from "@pages/GroupCalendarPage/page";
 import GroupListPage from "@pages/GroupListPage/page";
 import GroupMemberPage from "@pages/GroupMemberPage/page";
 import GroupScheduleDetailPage from "@pages/GroupScheduleDetailPage/page";
-import InvitingPage from "@pages/InvitingPage/page";
 import LocationSharingPage from "@pages/LocationSharingPage/page";
 import LoginPage from "@pages/LoginPage/page";
-import ModifyLocationPage from "@pages/ModifyLocationPage/page";
 import MyCalendarPage from "@pages/MyCalendarPage/page";
 import MyPage from "@pages/MyPage/page";
 import MyScheduleDetailPage from "@pages/MyScheduleDetailPage/page";
-import NotificationPage from "@pages/NotificationPage/page";
 import RegisterPage from "@pages/RegisterPage/page";
 import StartPage from "@pages/StartPage";
 import { Route, BrowserRouter as Router, Routes } from "react-router-dom";
 import "./App.module.css";
 import RegisterAccountPage from "@pages/RegisterAccountPage/page";
 import RegisterSuccessPage from "@pages/RegisterSuccessPage/page/inedx";
+import CommonRoute from "./routes/CommonRoute";
+import ProtectedRoute from "./routes/ProtectedRoute";
+import SelectLocationPage from "@pages/SelectLocationPage/page";
+import MyCalendarPossiblePage from "@pages/MyCalendarPossiblePage/page";
+import GroupCalendarPossiblePage from "@pages/GroupCalendarPossiblePage/page";
+import EditProfilePage from "@pages/EditProfilePage/page";
+import EditMySchedulePage from "@pages/EditMySchedulePage/page";
+import EditGroupSchedulePage from "@pages/EditGroupSchedulePage/page";
+import InviteGroupMemberPage from "@pages/InviteGroupMemberPage/page";
 
 function App() {
   return (
     <Router>
       <Routes>
         <Route path="/" element={<Layout />}>
-          <Route path="/" element={<StartPage />} />
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/register" element={<RegisterPage />} />
-          <Route path="/registerSuccess" element={<RegisterSuccessPage />} />
-          <Route path="/registerAccount" element={<RegisterAccountPage />} />
-          <Route path="/find" element={<FindPage />} />
-          <Route path="/myCalendar" element={<MyCalendarPage />} />
-          <Route path="/groupList" element={<GroupListPage />} />
-          <Route path="/group/:groupId" element={<GroupPage />} />
-          <Route path="/group/:groupId/members" element={<GroupMemberPage />} />
-          <Route path="/createGroup" element={<CreateGroupPage />} />
-          <Route path="/chatList" element={<ChatListPage />} />
-          <Route path="/chatList/search" element={<ChatListSearchPage />} />
-          <Route path="/group/:groupId/chatting" element={<ChattingPage />} />
-          <Route path="/group/:groupId/calendar" element={<GroupCalendarPage />} />
-          <Route
-            path="/group/:groupId/calendar/createSchedule"
-            element={<CreateGroupSchedulePage />}
-          />
-          <Route path="/createMySchedule" element={<CreateMySchedulePage />} />
-          <Route
-            path="/group/:groupId/calendar/schedule/:scheduleId"
-            element={<GroupScheduleDetailPage />}
-          />
-          <Route path="/modifyLocation" element={<ModifyLocationPage />} />
-          <Route path="/mySchedule/:scheduleId" element={<MyScheduleDetailPage />} />
-          <Route path="/myPage" element={<MyPage />} />
-          <Route path="/myPage/friendsManagement" element={<FriendManagementPage />} />
-          <Route path="/notification" element={<NotificationPage />} />
-          <Route
-            path="/group/:groupId/calendar/schedule/:scheduleId/locationSharing"
-            element={<LocationSharingPage />}
-          />
-          <Route path="/memberInvitation" element={<InvitingPage />} />
+          <Route element={<CommonRoute />}>
+            <Route path="/" element={<StartPage />} />
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/register" element={<RegisterPage />} />
+            <Route path="/registerSuccess" element={<RegisterSuccessPage />} />
+            <Route path="/find" element={<FindPage />} />
+          </Route>
+          <Route element={<ProtectedRoute />}>
+            <Route path="/registerAccount" element={<RegisterAccountPage />} />
+            <Route path="/myCalendar" element={<MyCalendarPage />} />
+            <Route path="/myCalendarPossible" element={<MyCalendarPossiblePage />} />
+            <Route path="/group/:groupId/calendar" element={<GroupCalendarPage />} />
+            <Route path="/groupCalendarPossible" element={<GroupCalendarPossiblePage />} />
+            <Route path="/chatList" element={<ChatListPage />} />
+            <Route path="/chatList/search" element={<ChatListSearchPage />} />
+            <Route path="/group/:groupId/chatting" element={<ChattingPage />} />
+            <Route path="/myPage" element={<MyPage />} />
+            <Route path="/myPage/editProfile" element={<EditProfilePage />} />
+            <Route path="/myPage/friendsManagement" element={<FriendManagementPage />} />
+            <Route path="/createMySchedule" element={<CreateMySchedulePage />} />
+            <Route
+              path="/group/:groupId/calendar/createSchedule"
+              element={<CreateGroupSchedulePage />}
+            />
+            <Route path="/selectLocation" element={<SelectLocationPage />} />
+            <Route path="/mySchedule/:scheduleId" element={<MyScheduleDetailPage />} />
+            <Route path="/mySchedule/:scheduleId/edit" element={<EditMySchedulePage />} />
+            <Route
+              path="/group/:groupId/calendar/schedule/:scheduleId"
+              element={<GroupScheduleDetailPage />}
+            />
+            <Route
+              path="/group/:groupId/calendar/schedule/:scheduleId/edit"
+              element={<EditGroupSchedulePage />}
+            />
+            <Route
+              path="/group/:groupId/calendar/schedule/:scheduleId/locationSharing"
+              element={<LocationSharingPage />}
+            />
+            <Route path="/createGroup" element={<CreateGroupPage />} />
+            <Route path="/groupList" element={<GroupListPage />} />
+            <Route path="/group/:groupId" element={<GroupPage />} />
+            <Route path="/group/:groupId/members" element={<GroupMemberPage />} />
+            <Route path="/group/:groupId/inviteGroupMember" element={<InviteGroupMemberPage/>}/>
+          </Route>
           <Route path="*" element={<ErrorPage />} />
         </Route>
       </Routes>

--- a/src/api/user/getUserInfo.ts
+++ b/src/api/user/getUserInfo.ts
@@ -10,7 +10,7 @@ type IGetUserInfoResponseType = {
   birthday: string;
 };
 
-const getUserInfo = async (accessToken: string):Promise<IGetUserInfoResponseType> => {
+const getUserInfo = async (accessToken: string): Promise<IGetUserInfoResponseType> => {
   return await api.get({
     endpoint: `${apiRoutes.userProfile}`,
     authorization: accessToken,
@@ -18,9 +18,9 @@ const getUserInfo = async (accessToken: string):Promise<IGetUserInfoResponseType
 };
 
 export const useGetUserInfo = (accessToken: string) => {
-    return useQuery({
-        queryKey: ['UserProfile'],
-        queryFn: () => getUserInfo(accessToken),
-      
-    })
-}
+  return useQuery({
+    queryKey: ["UserProfile"],
+    queryFn: () => getUserInfo(accessToken),
+    enabled: accessToken !== "",
+  });
+};

--- a/src/api/user/postUserInformation.ts
+++ b/src/api/user/postUserInformation.ts
@@ -1,5 +1,4 @@
 import apiRoutes from "@api/apiRoutes";
-import api from "@api/fetcher";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/EditGroupSchedulePage/page/index.tsx
+++ b/src/pages/EditGroupSchedulePage/page/index.tsx
@@ -1,0 +1,7 @@
+const EditGroupSchedulePage = () => {
+  return (
+    <div>EditGroupSchedulePage</div>
+  )
+}
+
+export default EditGroupSchedulePage

--- a/src/pages/EditMySchedulePage/page/index.tsx
+++ b/src/pages/EditMySchedulePage/page/index.tsx
@@ -1,0 +1,7 @@
+const EditMySchedulePage = () => {
+  return (
+    <div>EditMySchedulePage</div>
+  )
+}
+
+export default EditMySchedulePage

--- a/src/pages/EditProfilePage/page/index.tsx
+++ b/src/pages/EditProfilePage/page/index.tsx
@@ -1,0 +1,7 @@
+const EditProfilePage = () => {
+  return (
+    <div>EditProfilePage</div>
+  )
+}
+
+export default EditProfilePage

--- a/src/pages/GroupCalendarPossiblePage/page/index.tsx
+++ b/src/pages/GroupCalendarPossiblePage/page/index.tsx
@@ -1,0 +1,7 @@
+const GroupCalendarPossiblePage = () => {
+  return (
+    <div>GroupCalendarPossiblePage</div>
+  )
+}
+
+export default GroupCalendarPossiblePage

--- a/src/pages/InviteGroupMemberPage/page/index.tsx
+++ b/src/pages/InviteGroupMemberPage/page/index.tsx
@@ -1,0 +1,7 @@
+const InviteGroupMemberPage = () => {
+  return (
+    <div>InviteGroupMemberPage</div>
+  )
+}
+
+export default InviteGroupMemberPage

--- a/src/pages/InvitingPage/page/index.tsx
+++ b/src/pages/InvitingPage/page/index.tsx
@@ -1,5 +1,0 @@
-const InvitingPage: React.FC = () => {
-  return <div>InvitingPage</div>;
-};
-
-export default InvitingPage;

--- a/src/pages/ModifyLocationPage/page/index.tsx
+++ b/src/pages/ModifyLocationPage/page/index.tsx
@@ -1,5 +1,0 @@
-const ModifyLocationPage: React.FC = () => {
-  return <div>ModifyLocationPage</div>;
-};
-
-export default ModifyLocationPage;

--- a/src/pages/MyCalendarPossiblePage/page/index.tsx
+++ b/src/pages/MyCalendarPossiblePage/page/index.tsx
@@ -1,0 +1,7 @@
+const MyCalendarPossiblePage = () => {
+  return (
+    <div>MyCalendarPossiblePage</div>
+  )
+}
+
+export default MyCalendarPossiblePage

--- a/src/pages/NotificationPage/page/index.tsx
+++ b/src/pages/NotificationPage/page/index.tsx
@@ -1,5 +1,0 @@
-const NotificationPage: React.FC = () => {
-  return <div>NotificationPage</div>;
-};
-
-export default NotificationPage;

--- a/src/pages/SelectLocationPage/page/index.tsx
+++ b/src/pages/SelectLocationPage/page/index.tsx
@@ -1,0 +1,5 @@
+const SelectLocationPage: React.FC = () => {
+  return <div>SelectLocationPage</div>;
+};
+
+export default SelectLocationPage;

--- a/src/routes/CommonRoute.tsx
+++ b/src/routes/CommonRoute.tsx
@@ -1,9 +1,12 @@
+import { useGetUserInfo } from "@api/user/getUserInfo";
 import useAuthStore from "@store/useAuthStore";
 import { Navigate, Outlet } from "react-router-dom";
 
 const CommonRoute = () => {
-    const { accessToken } = useAuthStore();
-  if (accessToken) {
+  const { accessToken } = useAuthStore();
+  const { isSuccess } = useGetUserInfo(accessToken);
+
+  if (isSuccess) {
     return <Navigate to={"/myCalendar"} />;
   }
   return <Outlet />;

--- a/src/routes/CommonRoute.tsx
+++ b/src/routes/CommonRoute.tsx
@@ -1,0 +1,12 @@
+import useAuthStore from "@store/useAuthStore";
+import { Navigate, Outlet } from "react-router-dom";
+
+const CommonRoute = () => {
+    const { accessToken } = useAuthStore();
+  if (accessToken) {
+    return <Navigate to={"/myCalendar"} />;
+  }
+  return <Outlet />;
+};
+
+export default CommonRoute;

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -1,12 +1,12 @@
+import { useGetUserInfo } from "@api/user/getUserInfo";
 import useAuthStore from "@store/useAuthStore";
 import { Navigate, Outlet } from "react-router-dom";
 
 const ProtectedRoute = () => {
-    const { accessToken } = useAuthStore();
+  const { accessToken } = useAuthStore();
+  const { isSuccess } = useGetUserInfo(accessToken);
 
-  if (!accessToken) {
-    const currentPath = window.location.pathname + window.location.search;
-    localStorage.setItem("redirectedFrom", currentPath);
+  if (!isSuccess) {
     return <Navigate to="/" replace />;
   }
 

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -1,0 +1,16 @@
+import useAuthStore from "@store/useAuthStore";
+import { Navigate, Outlet } from "react-router-dom";
+
+const ProtectedRoute = () => {
+    const { accessToken } = useAuthStore();
+
+  if (!accessToken) {
+    const currentPath = window.location.pathname + window.location.search;
+    localStorage.setItem("redirectedFrom", currentPath);
+    return <Navigate to="/" replace />;
+  }
+
+  return <Outlet />;
+};
+
+export default ProtectedRoute;


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #67 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

> 1. 로그인 상태에 따른 페이지 리디렉션 로직 작성
> 2. 로그인 상태 여부는 accessToken 여부가 아닌 프로필 조회 api를 호출했을때의 성공 여부(isSuccess)를 따짐

## 📝수정 내용(선택)
> 1. src/pages 폴더의 페이지들 중 누락되거나 피그마에 없는 페이지들 추가 및 삭제, 라우팅 재설정
> - 삭제 : InvitingPage(초대 수락 페이지가 아닌 모달로 대체), NotificationPage(알림 페이지는 mvp아님)
> - 누락된 페이지 추가 : 
               MyCalendarPossiblePage(내 달력 -> 가능한 날짜 선택 페이지), 
               GroupCalendarPossiblePage(그룹 달력 -> 가능한 날짜 선택 페이지), 
               ProfileEditPage(피그마 상의 마이페이지 설정 = 프로필 수정 페이지), 
               EditMySchedulePage(개인 일정 수정 페이지), 
               EditGroupSchedulePage(그룹 일정 수정 페이지), 
               InviteGroupMemberPage(그룹 멤버 추가 페이지)


### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> - 이 작업으로 인해 시작 페이지, 로그인 페이지, 아이디/비밀번호 찾기 페이지, 회원가입 페이지, 회원가입 성공 페이지 이외의 페이지들 작업할 때는 로그인 필수 입니다. 로그인 안하고 이동하려고 하면 시작페이지로 리디렉션되니까 인지하고 작업해주세요‼️