### PR TITLE
Hotfix: 달력 페이지에서 사용되는 달력 컴포넌트 type === "view"일때 선택된 날짜의 값을 저장할 수 있도록 하는 set함수 props에 추가

### DIFF
--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -25,6 +25,7 @@ interface Props {
   setAvailableDates?: React.Dispatch<React.SetStateAction<string[]>>;
   scheduleData: IGetScheduleType[];
   groupAvailableDates?: IGetGroupPossibleScheduleType[];
+  setSelectedDate?: React.Dispatch<React.SetStateAction<string>>;
 }
 
 const Calendar: React.FC<Props> = ({
@@ -33,6 +34,7 @@ const Calendar: React.FC<Props> = ({
   setAvailableDates,
   scheduleData,
   groupAvailableDates,
+  setSelectedDate,
 }) => {
   const [currentMonth, setCurrentMonth] = useState(new Date());
 
@@ -73,6 +75,7 @@ const Calendar: React.FC<Props> = ({
     const handleDateClick = (date: string) => {
       const today = startOfDay(new Date());
       const selectedDate = startOfDay(new Date(date));
+      type === "view" && setSelectedDate!(date);
 
       if (type === "myPossible" && !isAfter(today, selectedDate)) {
         setAvailableDates!((prev) => {

--- a/src/pages/MyCalendarPage/page/index.tsx
+++ b/src/pages/MyCalendarPage/page/index.tsx
@@ -1,5 +1,5 @@
 import EditIcon from "@assets/Icons/myCalendar/EditIcon.svg?react";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Calendar from "../../../components/calendar/Calendar";
 import CalendarHeader from "../../../components/headers/CalendarHeader";
 import Footer from "../../../components/nav-bar/BottomNavBar";
@@ -14,8 +14,8 @@ interface IGetScheduleType {
 }
 
 const MyCalendarPage: React.FC = () => {
-  const [availableDates, setAvailableDates] = useState<string[]>([]);
   const navigate = useNavigate();
+  const [selectedDate, setSelectedDate] = useState<string>("");
 
   const scheduleData: IGetScheduleType[] = [
     { date: "2025-01-04", isSchedule: true, isBirthday: false },
@@ -25,8 +25,13 @@ const MyCalendarPage: React.FC = () => {
   ];
 
   const handleMiniCalendarClick = () => {
-    navigate('/myCalendarPossible')
-  }
+    navigate("/myCalendarPossible");
+  };
+
+  useEffect(() => {
+    // selectedDate의 값이 변할때마다 해당 날짜 일정 조회하는 api 호출
+    console.log(selectedDate);
+  }, [selectedDate]);
 
   return (
     <div className={styles.page}>
@@ -38,12 +43,7 @@ const MyCalendarPage: React.FC = () => {
 
       <div className={styles.content}>
         <div className={styles.calendarSection}>
-          <Calendar
-            type="view"
-            availableDates={availableDates}
-            setAvailableDates={setAvailableDates}
-            scheduleData={scheduleData}
-          />
+          <Calendar type="view" scheduleData={scheduleData} setSelectedDate={setSelectedDate} />
         </div>
         <div className={styles.scheduleSection}>
           <div className={styles.scheduleHeaderContainer}>


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #122 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)
> - 달력 컴포넌트에서 view===type일때 클릭된 날짜 값을 set할 수 있는 props추가(optional props)

## 📝수정 내용(선택)
> - 나의 달력 페이지에서는 달력 컴포넌트에 넘겨줄 Props중 가능한 날짜 배열에 관한 Props는 안넘겨줘도 되기 때문에 삭제

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)
