### PR TITLE
Feat: 그룹 목록 페이지에서 사용되는 api 연동(그룹 목록 조회, 그룹 초대 목록 조회, 그룹 초대 수락, 그룹 초대 거절)

### DIFF
--- a/src/api/group/getGroupInviteList.ts
+++ b/src/api/group/getGroupInviteList.ts
@@ -1,0 +1,23 @@
+import apiRoutes from "@api/apiRoutes";
+import api from "@api/fetcher";
+import { useQuery } from "@tanstack/react-query";
+
+type IResponseGetGroupInviteListType = {
+  data: IGetGroupInviteListItemType[];
+};
+
+const getGroupInviteList = async (authorization: string) => {
+  const response = await api.get<IResponseGetGroupInviteListType>({
+    endpoint: apiRoutes.showGroupInvitationList,
+    authorization,
+  });
+  return response;
+};
+
+export const useGetGroupInviteList = (authorization: string) => {
+  return useQuery({
+    queryKey: ["GROUP_INVITE_LIST"],
+    queryFn: () => getGroupInviteList(authorization),
+    enabled: authorization !== "",
+  });
+};

--- a/src/api/group/getGroupList.ts
+++ b/src/api/group/getGroupList.ts
@@ -1,0 +1,19 @@
+import apiRoutes from "@api/apiRoutes";
+import api from "@api/fetcher";
+import { useQuery } from "@tanstack/react-query";
+
+const getGroupList = async (authorization: string) => {
+  const response = await api.get<IGetGroupListItemType[]>({
+    endpoint: apiRoutes.showGroupList,
+    authorization,
+  });
+  return response;
+};
+
+export const useGetGroupList = (authorization: string) => {
+  return useQuery({
+    queryKey: ["GROUP_LIST"],
+    queryFn: () => getGroupList(authorization),
+    enabled: authorization !== "",
+  });
+};

--- a/src/api/group/getGroupList.ts
+++ b/src/api/group/getGroupList.ts
@@ -2,8 +2,12 @@ import apiRoutes from "@api/apiRoutes";
 import api from "@api/fetcher";
 import { useQuery } from "@tanstack/react-query";
 
+type IResponseGetGroupListType = {
+  data: IGetGroupListItemType[];
+}
+
 const getGroupList = async (authorization: string) => {
-  const response = await api.get<IGetGroupListItemType[]>({
+  const response = await api.get<IResponseGetGroupListType>({
     endpoint: apiRoutes.showGroupList,
     authorization,
   });

--- a/src/api/group/putGroupInviteAcceptOrReject.ts
+++ b/src/api/group/putGroupInviteAcceptOrReject.ts
@@ -1,0 +1,53 @@
+import apiRoutes from "@api/apiRoutes";
+import api from "@api/fetcher";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+const putGroupInviteAccept = async (authorization: string, groupId: number) => {
+  const response = await api.put<IResponseType>({
+    endpoint: `${apiRoutes.acceptGroupInvitation}/${groupId}`,
+    authorization,
+  });
+  return response;
+};
+
+export const usePutGroupInviteAccept = (
+  authorization: string,
+  setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (groupId: number) => putGroupInviteAccept(authorization, groupId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["GROUP_INVITE_LIST", "GROUP_LIST"],
+      });
+      setIsModalOpen(false);
+    },
+    onError: (error) => alert(error.message),
+  });
+};
+
+const deleteGroupInvite = async (authorization: string, groupId: number) => {
+  const response = await api.delete<IResponseType>({
+    endpoint: `${apiRoutes.rejectGroupInvitation}/${groupId}`,
+    authorization,
+  });
+  return response;
+};
+
+export const useDeleteGroupInvite = (
+  authorization: string,
+  setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (groupId: number) => deleteGroupInvite(authorization, groupId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["GROUP_INVITE_LIST", "GROUP_LIST"],
+      });
+      setIsModalOpen(false);
+    },
+    onError: (error) => alert(error.message),
+  });
+};

--- a/src/api/group/putGroupInviteAcceptOrReject.ts
+++ b/src/api/group/putGroupInviteAcceptOrReject.ts
@@ -19,7 +19,10 @@ export const usePutGroupInviteAccept = (
     mutationFn: (groupId: number) => putGroupInviteAccept(authorization, groupId),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["GROUP_INVITE_LIST", "GROUP_LIST"],
+        queryKey: ["GROUP_INVITE_LIST"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["GROUP_LIST"],
       });
       setIsModalOpen(false);
     },
@@ -44,7 +47,10 @@ export const useDeleteGroupInvite = (
     mutationFn: (groupId: number) => deleteGroupInvite(authorization, groupId),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["GROUP_INVITE_LIST", "GROUP_LIST"],
+        queryKey: ["GROUP_INVITE_LIST"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["GROUP_LIST"],
       });
       setIsModalOpen(false);
     },

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -25,6 +25,7 @@ interface Props {
   setAvailableDates?: React.Dispatch<React.SetStateAction<string[]>>;
   scheduleData: IGetScheduleType[];
   groupAvailableDates?: IGetGroupPossibleScheduleType[];
+  setSelectedDate?: React.Dispatch<React.SetStateAction<string>>;
 }
 
 const Calendar: React.FC<Props> = ({
@@ -33,6 +34,7 @@ const Calendar: React.FC<Props> = ({
   setAvailableDates,
   scheduleData,
   groupAvailableDates,
+  setSelectedDate,
 }) => {
   const [currentMonth, setCurrentMonth] = useState(new Date());
 
@@ -73,6 +75,7 @@ const Calendar: React.FC<Props> = ({
     const handleDateClick = (date: string) => {
       const today = startOfDay(new Date());
       const selectedDate = startOfDay(new Date(date));
+      type === "view" && setSelectedDate!(date);
 
       if (type === "myPossible" && !isAfter(today, selectedDate)) {
         setAvailableDates!((prev) => {

--- a/src/components/modals/inviteModal.module.scss
+++ b/src/components/modals/inviteModal.module.scss
@@ -35,6 +35,7 @@
           width: 100%;
           height: 100%;
           border-radius: 50%;
+          background-color: var(--white);
         }
       }
     }

--- a/src/pages/GroupListPage/components/GroupItem.tsx
+++ b/src/pages/GroupListPage/components/GroupItem.tsx
@@ -1,13 +1,23 @@
 import React from "react";
 import styles from "./groupItem.module.scss";
+import { useNavigate } from "react-router-dom";
 
 interface IProps {
   groupItem: IGetGroupListItemType;
 }
 
 const GroupItem: React.FC<IProps> = ({ groupItem }) => {
+  const navigate = useNavigate();
+  const handleGroupItemClick = (groupId: number) => {
+    navigate(`/group/${groupId}`);
+  };
+
   return (
-    <div className={styles.Container}>
+    <div
+      className={styles.Container}
+      key={groupItem.groupId}
+      onClick={() => handleGroupItemClick(groupItem.groupId)}
+    >
       <div className={styles.ProfileImg}>
         <img
           src={groupItem.groupImageUrl}

--- a/src/pages/GroupListPage/components/GroupItem.tsx
+++ b/src/pages/GroupListPage/components/GroupItem.tsx
@@ -1,18 +1,23 @@
 import React from "react";
 import styles from "./groupItem.module.scss";
-import DefaultProfileImage from "@assets/Icons/Default Profile/default_profile.svg?react";
 
-interface IProps {}
+interface IProps {
+  groupItem: IGetGroupListItemType;
+}
 
-const GroupItem: React.FC<IProps> = () => {
+const GroupItem: React.FC<IProps> = ({ groupItem }) => {
   return (
     <div className={styles.Container}>
       <div className={styles.ProfileImg}>
-        <DefaultProfileImage />
+        <img
+          src={groupItem.groupImageUrl}
+          alt={`${groupItem.groupName}의 프로필`}
+          className={styles.image}
+        />
       </div>
       <div className={styles.InfoBox}>
-        <p className={styles.GroupName}>planU 수다방</p>
-        <p className={styles.MembersNum}>• 7명 참여 중</p>
+        <p className={styles.GroupName}>{groupItem.groupName}</p>
+        <p className={styles.MembersNum}>• {groupItem.participant}명 참여 중</p>
       </div>
     </div>
   );

--- a/src/pages/GroupListPage/components/GroupItem.tsx
+++ b/src/pages/GroupListPage/components/GroupItem.tsx
@@ -15,7 +15,6 @@ const GroupItem: React.FC<IProps> = ({ groupItem }) => {
   return (
     <div
       className={styles.Container}
-      key={groupItem.groupId}
       onClick={() => handleGroupItemClick(groupItem.groupId)}
     >
       <div className={styles.ProfileImg}>

--- a/src/pages/GroupListPage/components/InviteItem.tsx
+++ b/src/pages/GroupListPage/components/InviteItem.tsx
@@ -1,6 +1,11 @@
 import React, { useState } from "react";
 import styles from "./groupItem.module.scss";
 import InviteModal from "@components/modals/InviteModal";
+import useAuthStore from "@store/useAuthStore";
+import {
+  useDeleteGroupInvite,
+  usePutGroupInviteAccept,
+} from "@api/group/putGroupInviteAcceptOrReject";
 
 interface IProps {
   groupInviteItem: IGetGroupInviteListItemType;
@@ -8,9 +13,18 @@ interface IProps {
 
 const InviteItem: React.FC<IProps> = ({ groupInviteItem }) => {
   const [isInviteModalOpen, setIsInviteModalOpen] = useState<boolean>(false);
-  const handleAcceptClick = () => {};
+  const { accessToken } = useAuthStore.getState();
+  const { mutate: acceptInvite } = usePutGroupInviteAccept(accessToken, setIsInviteModalOpen);
+  const { mutate: rejectInvite } = useDeleteGroupInvite(accessToken, setIsInviteModalOpen);
 
-  const handleRejectClick = () => {};
+  const handleAcceptClick = (groupId: number) => {
+    acceptInvite(groupId);
+  };
+
+  const handleRejectClick = (groupId: number) => {
+    rejectInvite(groupId);
+  };
+
   return (
     <div
       className={styles.Container}
@@ -33,8 +47,8 @@ const InviteItem: React.FC<IProps> = ({ groupInviteItem }) => {
           groupImage={groupInviteItem.groupImageUrl}
           groupName={groupInviteItem.groupName}
           setIsInviteModalOpen={setIsInviteModalOpen}
-          handleAcceptClick={handleAcceptClick}
-          handleRejectClick={handleRejectClick}
+          handleAcceptClick={() => handleAcceptClick(groupInviteItem.groupId)}
+          handleRejectClick={() => handleRejectClick(groupInviteItem.groupId)}
         />
       )}
     </div>

--- a/src/pages/GroupListPage/components/InviteItem.tsx
+++ b/src/pages/GroupListPage/components/InviteItem.tsx
@@ -1,34 +1,19 @@
-import React, { useState } from "react";
+import React from "react";
 import styles from "./groupItem.module.scss";
-import InviteModal from "@components/modals/InviteModal";
-import useAuthStore from "@store/useAuthStore";
-import {
-  useDeleteGroupInvite,
-  usePutGroupInviteAccept,
-} from "@api/group/putGroupInviteAcceptOrReject";
+
 
 interface IProps {
   groupInviteItem: IGetGroupInviteListItemType;
+  setIsInviteModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const InviteItem: React.FC<IProps> = ({ groupInviteItem }) => {
-  const [isInviteModalOpen, setIsInviteModalOpen] = useState<boolean>(false);
-  const { accessToken } = useAuthStore.getState();
-  const { mutate: acceptInvite } = usePutGroupInviteAccept(accessToken, setIsInviteModalOpen);
-  const { mutate: rejectInvite } = useDeleteGroupInvite(accessToken, setIsInviteModalOpen);
+const InviteItem: React.FC<IProps> = ({ groupInviteItem,setIsInviteModalOpen }) => {
+  
 
-  const handleAcceptClick = (groupId: number) => {
-    acceptInvite(groupId);
-  };
-
-  const handleRejectClick = (groupId: number) => {
-    rejectInvite(groupId);
-  };
 
   return (
     <div
       className={styles.Container}
-      key={groupInviteItem.groupId}
       onClick={() => setIsInviteModalOpen(true)}
     >
       <div className={styles.ProfileImg}>
@@ -41,16 +26,7 @@ const InviteItem: React.FC<IProps> = ({ groupInviteItem }) => {
       <div className={styles.InfoBox}>
         <p className={styles.GroupName}>{groupInviteItem.groupName}</p>
       </div>
-      {isInviteModalOpen && (
-        <InviteModal
-          groupId={groupInviteItem.groupId}
-          groupImage={groupInviteItem.groupImageUrl}
-          groupName={groupInviteItem.groupName}
-          setIsInviteModalOpen={setIsInviteModalOpen}
-          handleAcceptClick={() => handleAcceptClick(groupInviteItem.groupId)}
-          handleRejectClick={() => handleRejectClick(groupInviteItem.groupId)}
-        />
-      )}
+      
     </div>
   );
 };

--- a/src/pages/GroupListPage/components/InviteItem.tsx
+++ b/src/pages/GroupListPage/components/InviteItem.tsx
@@ -1,18 +1,42 @@
-import React from "react";
+import React, { useState } from "react";
 import styles from "./groupItem.module.scss";
-import DefaultProfileImage from "@assets/Icons/Default Profile/default_profile.svg?react";
+import InviteModal from "@components/modals/InviteModal";
 
-interface IProps {}
+interface IProps {
+  groupInviteItem: IGetGroupInviteListItemType;
+}
 
-const InviteItem: React.FC<IProps> = () => {
+const InviteItem: React.FC<IProps> = ({ groupInviteItem }) => {
+  const [isInviteModalOpen, setIsInviteModalOpen] = useState<boolean>(false);
+  const handleAcceptClick = () => {};
+
+  const handleRejectClick = () => {};
   return (
-    <div className={styles.Container}>
+    <div
+      className={styles.Container}
+      key={groupInviteItem.groupId}
+      onClick={() => setIsInviteModalOpen(true)}
+    >
       <div className={styles.ProfileImg}>
-        <DefaultProfileImage />
+        <img
+          src={groupInviteItem.groupImageUrl}
+          alt={`${groupInviteItem.groupName}의 프로필`}
+          className={styles.image}
+        />
       </div>
       <div className={styles.InfoBox}>
-        <p className={styles.GroupName}>planU 수다방</p>
+        <p className={styles.GroupName}>{groupInviteItem.groupName}</p>
       </div>
+      {isInviteModalOpen && (
+        <InviteModal
+          groupId={groupInviteItem.groupId}
+          groupImage={groupInviteItem.groupImageUrl}
+          groupName={groupInviteItem.groupName}
+          setIsInviteModalOpen={setIsInviteModalOpen}
+          handleAcceptClick={handleAcceptClick}
+          handleRejectClick={handleRejectClick}
+        />
+      )}
     </div>
   );
 };

--- a/src/pages/GroupListPage/components/groupItem.module.scss
+++ b/src/pages/GroupListPage/components/groupItem.module.scss
@@ -5,6 +5,7 @@
   border-bottom: 1px solid var(--gray-200);
   align-items: center;
   gap: 20px;
+  cursor: pointer;
 
   .ProfileImg {
     width: 53px;

--- a/src/pages/GroupListPage/components/groupItem.module.scss
+++ b/src/pages/GroupListPage/components/groupItem.module.scss
@@ -14,6 +14,12 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    .image {
+      width: 100%;
+      height: 100%;
+      border-radius: 100%;
+      object-fit: fill;
+    }
   }
 
   .InfoBox {

--- a/src/pages/GroupListPage/page/groupList.module.scss
+++ b/src/pages/GroupListPage/page/groupList.module.scss
@@ -2,7 +2,8 @@
   background-color: var(--background-50);
   height: 100dvh;
   position: relative;
-  overflow: scroll;
+  overflow: auto;
+  padding-bottom: 80px;
 
   .Border {
     height: 17px;
@@ -18,10 +19,10 @@
 
   .AddIcon {
     cursor: pointer;
-    position: sticky;
-    bottom: 15%;
-    left: 80%;
-  }
+    position: fixed;
+    bottom: 100px;
+    right: 30%;
+  } 
 }
 
 .TitleP {

--- a/src/pages/GroupListPage/page/groupList.module.scss
+++ b/src/pages/GroupListPage/page/groupList.module.scss
@@ -1,9 +1,10 @@
 .Container {
   background-color: var(--background-50);
-  height: 100dvh;
+  height: 100vh;
   position: relative;
   overflow: auto;
   padding-bottom: 80px;
+  scrollbar-width: none;
 
   .Border {
     height: 17px;
@@ -19,10 +20,11 @@
 
   .AddIcon {
     cursor: pointer;
-    position: fixed;
-    bottom: 100px;
-    right: 30%;
-  } 
+    position: sticky;
+    z-index: 10;
+    bottom: 15%;
+    left: 80%;
+  }
 }
 
 .TitleP {

--- a/src/pages/GroupListPage/page/groupList.module.scss
+++ b/src/pages/GroupListPage/page/groupList.module.scss
@@ -10,8 +10,7 @@
   }
 
   .ContentBox {
-    padding: 0 20px;
-    margin-bottom: 20px;
+    padding: 10px 20px 20px 20px;
     display: flex;
     flex-direction: column;
     gap: 10px;

--- a/src/pages/GroupListPage/page/index.tsx
+++ b/src/pages/GroupListPage/page/index.tsx
@@ -7,11 +7,13 @@ import { useNavigate } from "react-router-dom";
 import InviteItem from "../components/InviteItem";
 import useAuthStore from "@store/useAuthStore";
 import { useGetGroupList } from "@api/group/getGroupList";
+import { useGetGroupInviteList } from "@api/group/getGroupInviteList";
 
 const GroupListPage: React.FC = () => {
   const navigate = useNavigate();
   const { accessToken } = useAuthStore.getState();
   const { data: groupList } = useGetGroupList(accessToken);
+  const { data: groupInviteList } = useGetGroupInviteList(accessToken);
 
   return (
     <div className={styles.Container}>
@@ -22,19 +24,23 @@ const GroupListPage: React.FC = () => {
           return;
         }}
       />
-      <div className={styles.Border} />
-      <div className={styles.ContentBox}>
-        <p className={styles.TitleP}>Invitation Request</p>
-        <InviteItem />
-        <InviteItem />
-      </div>
+      {groupInviteList && groupInviteList.data.length !== 0 && (
+        <>
+          <div className={styles.Border} />
+          <div className={styles.ContentBox}>
+            <p className={styles.TitleP}>Invitation Request</p>
+            {groupInviteList.data.map((groupInviteItem) => (
+              <InviteItem groupInviteItem={groupInviteItem}  />
+            ))}
+          </div>
+        </>
+      )}
+      
+
       <div className={styles.Border} />
       <div className={styles.ContentBox}>
         <p className={styles.TitleP}>MyGroup</p>
-        {groupList &&
-          groupList.map((groupItem) => {
-            return <GroupItem groupItem={groupItem} />;
-          })}
+        {groupList && groupList.data.map((groupItem) => <GroupItem groupItem={groupItem} />)}
       </div>
       <div className={styles.Border} />
       <Icon_add className={styles.AddIcon} onClick={() => navigate("/createGroup")} />

--- a/src/pages/GroupListPage/page/index.tsx
+++ b/src/pages/GroupListPage/page/index.tsx
@@ -8,12 +8,30 @@ import InviteItem from "../components/InviteItem";
 import useAuthStore from "@store/useAuthStore";
 import { useGetGroupList } from "@api/group/getGroupList";
 import { useGetGroupInviteList } from "@api/group/getGroupInviteList";
+import { useState } from "react";
+import InviteModal from "@components/modals/InviteModal";
+import {
+  useDeleteGroupInvite,
+  usePutGroupInviteAccept,
+} from "@api/group/putGroupInviteAcceptOrReject";
 
 const GroupListPage: React.FC = () => {
   const navigate = useNavigate();
   const { accessToken } = useAuthStore.getState();
   const { data: groupList } = useGetGroupList(accessToken);
   const { data: groupInviteList } = useGetGroupInviteList(accessToken);
+  const [isInviteModalOpen, setIsInviteModalOpen] = useState<boolean>(false);
+
+  const { mutate: acceptInvite } = usePutGroupInviteAccept(accessToken, setIsInviteModalOpen);
+  const { mutate: rejectInvite } = useDeleteGroupInvite(accessToken, setIsInviteModalOpen);
+
+  const handleAcceptClick = (groupId: number) => {
+    acceptInvite(groupId);
+  };
+
+  const handleRejectClick = (groupId: number) => {
+    rejectInvite(groupId);
+  };
 
   return (
     <div className={styles.Container}>
@@ -30,17 +48,35 @@ const GroupListPage: React.FC = () => {
           <div className={styles.ContentBox}>
             <p className={styles.TitleP}>Invitation Request</p>
             {groupInviteList.data.map((groupInviteItem) => (
-              <InviteItem groupInviteItem={groupInviteItem}  />
+              <>
+                <InviteItem
+                  groupInviteItem={groupInviteItem}
+                  key={groupInviteItem.groupId}
+                  setIsInviteModalOpen={setIsInviteModalOpen}
+                />
+                {isInviteModalOpen && (
+                  <InviteModal
+                    groupId={groupInviteItem.groupId}
+                    groupImage={groupInviteItem.groupImageUrl}
+                    groupName={groupInviteItem.groupName}
+                    setIsInviteModalOpen={setIsInviteModalOpen}
+                    handleAcceptClick={() => handleAcceptClick(groupInviteItem.groupId)}
+                    handleRejectClick={() => handleRejectClick(groupInviteItem.groupId)}
+                  />
+                )}
+              </>
             ))}
           </div>
         </>
       )}
-      
 
       <div className={styles.Border} />
       <div className={styles.ContentBox}>
         <p className={styles.TitleP}>MyGroup</p>
-        {groupList && groupList.data.map((groupItem) => <GroupItem groupItem={groupItem} />)}
+        {groupList &&
+          groupList.data.map((groupItem) => (
+            <GroupItem groupItem={groupItem} key={groupItem.groupId} />
+          ))}
       </div>
       <div className={styles.Border} />
       <Icon_add className={styles.AddIcon} onClick={() => navigate("/createGroup")} />

--- a/src/pages/GroupListPage/page/index.tsx
+++ b/src/pages/GroupListPage/page/index.tsx
@@ -5,9 +5,13 @@ import GroupItem from "../components/GroupItem";
 import Icon_add from "../../../assets/Icons/Icon_add_circle.svg?react";
 import { useNavigate } from "react-router-dom";
 import InviteItem from "../components/InviteItem";
+import useAuthStore from "@store/useAuthStore";
+import { useGetGroupList } from "@api/group/getGroupList";
 
 const GroupListPage: React.FC = () => {
   const navigate = useNavigate();
+  const { accessToken } = useAuthStore.getState();
+  const { data: groupList } = useGetGroupList(accessToken);
 
   return (
     <div className={styles.Container}>
@@ -27,11 +31,10 @@ const GroupListPage: React.FC = () => {
       <div className={styles.Border} />
       <div className={styles.ContentBox}>
         <p className={styles.TitleP}>MyGroup</p>
-        <GroupItem />
-        <GroupItem />
-        <GroupItem />
-        <GroupItem />
-        <GroupItem />
+        {groupList &&
+          groupList.map((groupItem) => {
+            return <GroupItem groupItem={groupItem} />;
+          })}
       </div>
       <div className={styles.Border} />
       <Icon_add className={styles.AddIcon} onClick={() => navigate("/createGroup")} />

--- a/src/pages/MyCalendarPage/page/index.tsx
+++ b/src/pages/MyCalendarPage/page/index.tsx
@@ -1,5 +1,5 @@
 import EditIcon from "@assets/Icons/myCalendar/EditIcon.svg?react";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Calendar from "../../../components/calendar/Calendar";
 import CalendarHeader from "../../../components/headers/CalendarHeader";
 import Footer from "../../../components/nav-bar/BottomNavBar";
@@ -14,8 +14,8 @@ interface IGetScheduleType {
 }
 
 const MyCalendarPage: React.FC = () => {
-  const [availableDates, setAvailableDates] = useState<string[]>([]);
   const navigate = useNavigate();
+  const [selectedDate, setSelectedDate] = useState<string>("");
 
   const scheduleData: IGetScheduleType[] = [
     { date: "2025-01-04", isSchedule: true, isBirthday: false },
@@ -25,8 +25,13 @@ const MyCalendarPage: React.FC = () => {
   ];
 
   const handleMiniCalendarClick = () => {
-    navigate('/myCalendarPossible')
-  }
+    navigate("/myCalendarPossible");
+  };
+
+  useEffect(() => {
+    // selectedDate의 값이 변할때마다 해당 날짜 일정 조회하는 api 호출
+    console.log(selectedDate);
+  }, [selectedDate]);
 
   return (
     <div className={styles.page}>
@@ -38,12 +43,7 @@ const MyCalendarPage: React.FC = () => {
 
       <div className={styles.content}>
         <div className={styles.calendarSection}>
-          <Calendar
-            type="view"
-            availableDates={availableDates}
-            setAvailableDates={setAvailableDates}
-            scheduleData={scheduleData}
-          />
+          <Calendar type="view" scheduleData={scheduleData} setSelectedDate={setSelectedDate} />
         </div>
         <div className={styles.scheduleSection}>
           <div className={styles.scheduleHeaderContainer}>

--- a/src/types/get.d.ts
+++ b/src/types/get.d.ts
@@ -56,3 +56,10 @@ type IGetGroupMemberItemType = {
     name: string;
     profileImage: string;
 }
+
+type IGetGroupListItemType = {
+    groupId: number;
+    groupName: string;
+    groupImageUrl: string;
+    participant: number;
+}

--- a/src/types/get.d.ts
+++ b/src/types/get.d.ts
@@ -57,9 +57,12 @@ type IGetGroupMemberItemType = {
     profileImage: string;
 }
 
-type IGetGroupListItemType = {
+type IGetGroupListItemType = IGetGroupInviteListItemType & {
+    participant: number;
+}
+
+type IGetGroupInviteListItemType = {
     groupId: number;
     groupName: string;
     groupImageUrl: string;
-    participant: number;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #117 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)
> 1. 그룹 목록 페이지에서 사용되는 api 연동(그룹 목록 조회, 그룹 초대 목록 조회, 그룹 초대 수락, 그룹 초대 거절)
> 2. 초대 수락 및 거절 시 쿼리 무효화 로직 추가로 자동 그룹목록, 그룹 초대 목록 새로 조회
> 3. 그룹 목록 조회 데이터 타입 정의
> 4. 그룹 초대 목록에서 아이템 클릭했을 때 InviteModal 뜨도록 로직 작성

## 📝수정 내용(선택)
> 1. 그룹 목록 페이지 scroll-width: none으로 수정

### 스크린샷 (선택)
<img width="200" alt="스크린샷 2025-01-21 오후 6 43 49" src="https://github.com/user-attachments/assets/69f8fa2c-a92a-40e6-9441-b84c81a67b09" />
<img width="200" alt="스크린샷 2025-01-21 오후 6 44 16" src="https://github.com/user-attachments/assets/1cc90bc9-d20c-414d-898a-57d07a4ccd51" />

## 💬리뷰 요구사항(선택)
> - 사진에서도 보다시피 현재 AddIcon의 position이 sticky인데도 불구하고 bottom속성이 적용이 안되고 MyGroup 컨테이너 아래에 딱붙어있는 에러를 발견했습니다. 그래서 MyGroup의 Item 개수에 따라 AddIcon위치도 바뀝니다. 아무리 수정해도 bottomNavBar 바로 위에 배치가 안되더라구요. 해결해주세요,,
