### PR TITLE
Hotfix: api 연동 테스트 문제 해결 및 페이지 레이아웃 수정

### DIFF
--- a/src/api/group/deleteForcedWithdrawalFromGroup.ts
+++ b/src/api/group/deleteForcedWithdrawalFromGroup.ts
@@ -3,7 +3,7 @@ import api from "@api/fetcher";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 const deleteForcedWithdrawalFromGroup = async (authorization: string, groupId: number, username: string) => {
-  const response = await api.put<IResponseType>({
+  const response = await api.delete<IResponseType>({
     endpoint: `${apiRoutes.group}/${groupId}/members/${username}`,
     authorization,
   });

--- a/src/api/group/deleteGroup.ts
+++ b/src/api/group/deleteGroup.ts
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 
 const deleteGroup = async (authorization: string, groupId: number) => {
-  const response = await api.put<IResponseType>({
+  const response = await api.delete<IResponseType>({
     endpoint: `${apiRoutes.deleteGroup}/${groupId}`,
     authorization,
   });

--- a/src/api/group/deleteLeaveGroup.ts
+++ b/src/api/group/deleteLeaveGroup.ts
@@ -4,7 +4,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 
 const deleteLeaveGroup = async (authorization: string, groupId: number) => {
-  const response = await api.put<IResponseType>({
+  const response = await api.delete<IResponseType>({
     endpoint: `${apiRoutes.leaveGroup}/${groupId}`,
     authorization,
   });

--- a/src/components/headers/HasOnlyRightIconHeader.tsx
+++ b/src/components/headers/HasOnlyRightIconHeader.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import styles from "./hasOnlyRightIconHeader.module.scss";
-import StarIcon from "@components/iconComponent/StarIcon";
 import RedDot_Icon from "@assets/Icons/headers/redDot.svg?react";
 import Alert_Icon from "@assets/Icons/headers/alertIcon.svg?react";
 import X_Icon from "@assets/Icons/headers/xIcon.svg?react";
@@ -33,8 +32,6 @@ const HasOnlyRightIconHeader: React.FC<Props> = ({
             <Alert_Icon width={24} height={24} className={styles.alertIcon} onClick={handleClick} />
             {isExistNoReadAlarms && <RedDot_Icon className={styles.redDotIcon} />}
           </div>
-        ) : rightType === "star" ? (
-          <StarIcon isBookmark={isBookmark} id={groupId} handleClick={handleClick} />
         ) : rightType === "x" ? (
           <X_Icon width={24} height={24} />
         ) : rightType === "button" ? (

--- a/src/components/headers/HasTwoIconHeader.tsx
+++ b/src/components/headers/HasTwoIconHeader.tsx
@@ -4,13 +4,16 @@ import More_Icon from "@assets/Icons/headers/moreIcon.svg?react";
 import BackArrow2_Icon from "@assets/Icons/headers/backArrow2.svg?react";
 import Check_Icon from "@assets/Icons/headers/checkIcon.svg?react";
 import MiniButton from "@components/buttons/MiniButton";
+import StarIcon from "@components/iconComponent/StarIcon";
 
 interface Props {
   title: string;
-  rightType: "moreIcon" | "checkIcon" | "button";
+  rightType: "moreIcon" | "checkIcon" | "button" | "star";
   handleLeftClick: () => void;
   handleRightClick: () => void;
   backgroundColor: "purple" | "white";
+  isBookmark?: boolean;
+  groupId?: number;
 }
 
 const HasTwoIconHeader: React.FC<Props> = ({
@@ -19,6 +22,8 @@ const HasTwoIconHeader: React.FC<Props> = ({
   handleLeftClick,
   handleRightClick,
   backgroundColor,
+  isBookmark,
+  groupId
 }) => {
   return (
     <div className={`${styles.mainContainer} ${styles[backgroundColor]}`}>
@@ -31,7 +36,9 @@ const HasTwoIconHeader: React.FC<Props> = ({
           <More_Icon width={20} height={26} />
         ) : rightType === "checkIcon" ? (
           <Check_Icon width={24} height={24} />
-        ) : (
+        ) : rightType === "star" ? (
+          <StarIcon isBookmark={isBookmark} id={groupId} handleClick={handleRightClick} />
+        ): (
           <MiniButton
             buttonText="완료"
             color="purple"

--- a/src/pages/GroupMemberPage/components/MemberItem.tsx
+++ b/src/pages/GroupMemberPage/components/MemberItem.tsx
@@ -199,7 +199,7 @@ const MemberItem: React.FC<Props> = ({ memberInfo, isUserLeader }) => {
     <div className={styles.memberItemContainer}>
       <div className={styles.leftSection}>
         <div className={styles.profileSection}>
-          <img src={memberInfo.profileImage} width={38} height={37} alt="profile" />
+          <img src={memberInfo.profileImage} width={38} height={37} alt="profile" className={styles.profile} />
           {memberInfo.groupRole === "LEADER" && (
             <CrownIcon width={29} height={25} className={styles.crownIcon} />
           )}

--- a/src/pages/GroupMemberPage/components/memberItem.module.scss
+++ b/src/pages/GroupMemberPage/components/memberItem.module.scss
@@ -22,6 +22,11 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      .profile{
+        width: 100%;
+        height: 100%;
+        border-radius: 50%;
+      }
       .crownIcon {
         position: absolute;
         top: 0;

--- a/src/pages/GroupPage/components/groupOptions.module.scss
+++ b/src/pages/GroupPage/components/groupOptions.module.scss
@@ -11,7 +11,7 @@
     border-radius: 10px;
 
     .titleSection{
-        font-size: 5px;
+        font-size: 9px;
         font-weight:400;
         color: var(--black);
     }

--- a/src/pages/GroupPage/page/index.tsx
+++ b/src/pages/GroupPage/page/index.tsx
@@ -1,11 +1,10 @@
-import HasOnlyRightIconHeader from "@components/headers/HasOnlyRightIconHeader";
 import styles from "./groupPage.module.scss";
 import { useState } from "react";
 import GroupOptions from "../components/GroupOptions";
 import { useNavigate, useParams } from "react-router-dom";
 import TodayScheduleList from "../components/TodayScheduleList";
-import BottomNavBar from "@components/nav-bar/BottomNavBar";
 import GroupScheduleCalendar from "../components/GroupScheduleCalendar";
+import HasTwoIconHeader from "@components/headers/HasTwoIconHeader";
 
 const iconOptionsTitle = ["정산하기", "그룹 달력", "게시물", "멤버", "채팅"];
 
@@ -85,16 +84,18 @@ const GroupPage = () => {
 
   const handleCalendarClick = () => {
     navigate(`/group/${groupInfo.id}/groupCalendar`);
-  }
+  };
 
   return (
     <div className={styles.mainContainer}>
-      <HasOnlyRightIconHeader
+      <HasTwoIconHeader
+        backgroundColor="purple"
         title={groupInfo.name}
         rightType="star"
         isBookmark={groupInfo.isBookMark}
         groupId={groupInfo.id}
-        handleClick={handleBookMarkClick}
+        handleLeftClick={() => navigate(-1)}
+        handleRightClick={handleBookMarkClick}
       />
       <div className={styles.contentContainer}>
         <div className={styles.iconSection}>
@@ -112,7 +113,6 @@ const GroupPage = () => {
           <GroupScheduleCalendar groupSchedules={groupSchedules} onClick={handleCalendarClick} />
         </div>
       </div>
-      <BottomNavBar />
     </div>
   );
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #132

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

## 📝수정 내용(선택)

> 1. 그룹 멤버 목록 페이지에서 기본 프로필이 아닌 사용자의 프로필 이미지가 의도한 border-radius로 나오지 않는 오류 발생
       - 프로필 이미지 태그를 감싸고 있는 div의 width, height, border-radius에 맞게 img태그에도 css 속성을 지정해줌
> 2. 그룹 페이지의 상단에 있는 아이콘박스의 텍스트 크기가 너무 작아 보이지 않는 오류 발생
       - font-size : 4px -> 9px 로 수정
> 3. 그룹 페이지의 상단 헤더에 뒤로가기 버튼 추가 및 바텀 네비게이션 바 삭제
> 4. 그룹 삭제, 그룹 강제 탈퇴, 그룹 탈퇴 api 호출 로직에서 put -> delete로 수정 후 테스트 완료
       - 강퇴당하거나 삭제된 그룹의 그룹원들은 바로 그룹 목록 페이지로 리디렉션 되지 않는 에러 발생했지만 mvp 기능 구현전까진 보류

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

