### PR TITLE
Feat: 그룹 달력 페이지 api 연동(그룹 달력 일정 유무 조회, 그룹 달력 일정 조회)

### DIFF
--- a/src/api/calendar/getGroupCalendarCheckEvents.ts
+++ b/src/api/calendar/getGroupCalendarCheckEvents.ts
@@ -1,21 +1,27 @@
-import apiRoutes from "@api/apiRoutes"
-import api from "@api/fetcher"
+import apiRoutes from "@api/apiRoutes";
+import api from "@api/fetcher";
 import { useQuery } from "@tanstack/react-query";
 
-const getGroupCalendarCheckEvents = async (groupId: string, yearMonth: string, authorization: string) => {
-    const response =
-      api.get <
-      IGetGroupCalendarCheckEventsResponseBodyType>({
-        endpoint: `${apiRoutes.group}/${groupId}/schedules/check-events?yearMonth=${yearMonth}`,
-        authorization,
-      });
-    return response
-}
+const getGroupCalendarCheckEvents = async (
+  groupId: string,
+  yearMonth: string,
+  authorization: string,
+) => {
+  const response = api.get<IGetGroupCalendarCheckEventsResponseBodyType>({
+    endpoint: `${apiRoutes.group}/${groupId}/schedules/check-events?yearMonth=${yearMonth}`,
+    authorization,
+  });
+  return response;
+};
 
-export const useGetGroupCalendarCheckEvents = (groupId: string, yearMonth: string, authorization: string) => {
-    return useQuery({
-        queryKey: ["GROUP_CHECK_EVENTS", yearMonth],
-        queryFn: () => getGroupCalendarCheckEvents(groupId, yearMonth, authorization),
-        enabled: authorization !== null
-    })
-}
+export const useGetGroupCalendarCheckEvents = (
+  groupId: string,
+  yearMonth: string,
+  authorization: string,
+) => {
+  return useQuery({
+    queryKey: ["GROUP_CHECK_EVENTS", groupId, yearMonth],
+    queryFn: () => getGroupCalendarCheckEvents(groupId, yearMonth, authorization),
+    enabled: groupId !== undefined && authorization !== null,
+  });
+};

--- a/src/api/calendar/getGroupCalendarCheckEvents.ts
+++ b/src/api/calendar/getGroupCalendarCheckEvents.ts
@@ -1,0 +1,21 @@
+import apiRoutes from "@api/apiRoutes"
+import api from "@api/fetcher"
+import { useQuery } from "@tanstack/react-query";
+
+const getGroupCalendarCheckEvents = async (groupId: string, yearMonth: string, authorization: string) => {
+    const response =
+      api.get <
+      IGetGroupCalendarCheckEventsResponseBodyType>({
+        endpoint: `${apiRoutes.group}/${groupId}/schedules/check-events?yearMonth=${yearMonth}`,
+        authorization,
+      });
+    return response
+}
+
+export const useGetGroupCalendarCheckEvents = (groupId: string, yearMonth: string, authorization: string) => {
+    return useQuery({
+        queryKey: ["GROUP_CHECK_EVENTS", yearMonth],
+        queryFn: () => getGroupCalendarCheckEvents(groupId, yearMonth, authorization),
+        enabled: authorization !== null
+    })
+}

--- a/src/api/calendar/getGroupScheduleList.ts
+++ b/src/api/calendar/getGroupScheduleList.ts
@@ -1,0 +1,19 @@
+import apiRoutes from "@api/apiRoutes";
+import api from "@api/fetcher"
+import { useQuery } from "@tanstack/react-query";
+
+const getGroupScheduleList = async (groupId: string, authorization: string, selectedDate: string) => {
+    const response = api.get<IGetScheduleListResponseBodyType>({
+        endpoint: `${apiRoutes.group}/${groupId}/schedules/list?startDate=${selectedDate}&endDate=${selectedDate}`,
+        authorization
+    });
+    return response;
+}
+
+export const useGetGroupScheduleList = (groupId: string, authorization: string, selectedDate:string) => {
+    return useQuery({
+        queryKey: ["GROUP_SCHEDULE_LIST", groupId, selectedDate],
+        queryFn: () => getGroupScheduleList(groupId, authorization, selectedDate),
+        enabled: groupId !== undefined && authorization !== ""
+    })
+}

--- a/src/api/group/getGroupCalendarSchedules.ts
+++ b/src/api/group/getGroupCalendarSchedules.ts
@@ -20,8 +20,8 @@ export const useGetGroupCalendarSchedules = (
   yearMonth: string,
 ) => {
   return useQuery({
-    queryKey: ["GROUP_CALENDAR_SCHEDULES"],
+    queryKey: ["GROUP_CALENDAR_SCHEDULES", groupId],
     queryFn: () => getGroupCalendarSchedules(groupId, authorization, yearMonth),
-    enabled: authorization !== null,
+    enabled: groupId !== undefined && authorization !== "",
   });
 };

--- a/src/api/group/getGroupDetail.ts
+++ b/src/api/group/getGroupDetail.ts
@@ -12,7 +12,8 @@ const getGroupDetails = async (groupId: string, authorization: string) => {
 
 export const useGetGroupDetails = (groupId: string, authorization: string) => {
   return useQuery({
-    queryKey: ["GROUP_DETAILS"],
+    queryKey: ["GROUP_DETAILS", groupId],
     queryFn: () => getGroupDetails(groupId, authorization),
+    enabled: groupId !== undefined && authorization !== "",
   });
 };

--- a/src/api/group/getGroupMemberInviteList.ts
+++ b/src/api/group/getGroupMemberInviteList.ts
@@ -25,6 +25,6 @@ export const useGetGroupMemberInviteList = (
   return useQuery({
     queryKey: ["GROUP_MEMBER_INVITE_LIST"],
     queryFn: () => getGroupMemberInviteList(groupId, authorization, searchInput),
-    enabled: authorization !== null,
+    enabled: groupId !== undefined && authorization !== "",
   });
 };

--- a/src/api/group/getGroupMemberList.ts
+++ b/src/api/group/getGroupMemberList.ts
@@ -14,6 +14,6 @@ export const useGetGroupMemberList = (authorization: string, groupId: string) =>
   return useQuery({
     queryKey: ["GROUP_MEMBER_LIST", groupId],
     queryFn: () => getGroupMemberList(authorization, groupId),
-    enabled: authorization !== "",
+    enabled: groupId !== undefined && authorization !== "",
   });
 };

--- a/src/api/group/getGroupTodaySchedules.ts
+++ b/src/api/group/getGroupTodaySchedules.ts
@@ -12,8 +12,8 @@ const getGroupTodaySchedules = async (groupId: string, authorization: string) =>
 
 export const useGetGroupTodaySchedules = (groupId: string, authorization: string) => {
   return useQuery({
-    queryKey: ["GROUP_TODAY_SCHEDULES"],
+    queryKey: ["GROUP_TODAY_SCHEDULES", groupId],
     queryFn: () => getGroupTodaySchedules(groupId, authorization),
-    enabled: authorization !== null,
+    enabled: groupId !== undefined && authorization !== "",
   });
 };

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { JSX, useState } from "react";
 import {
   addMonths,
   subMonths,
@@ -23,9 +23,11 @@ interface Props {
   type: "view" | "myPossible" | "groupPossible";
   availableDates?: string[];
   setAvailableDates?: React.Dispatch<React.SetStateAction<string[]>>;
-  scheduleData: IGetScheduleType[];
+  scheduleData: IGroupScheduleType[] | undefined;
   groupAvailableDates?: IGetGroupPossibleScheduleType[];
   setSelectedDate?: React.Dispatch<React.SetStateAction<string>>;
+  currentMonth: Date;
+  setCurrentMonth: React.Dispatch<React.SetStateAction<Date>>;
 }
 
 const Calendar: React.FC<Props> = ({
@@ -35,8 +37,9 @@ const Calendar: React.FC<Props> = ({
   scheduleData,
   groupAvailableDates,
   setSelectedDate,
+  currentMonth,
+  setCurrentMonth
 }) => {
-  const [currentMonth, setCurrentMonth] = useState(new Date());
 
   const handlePrevMonth = () => {
     setCurrentMonth((prev) => subMonths(prev, 1));
@@ -93,7 +96,7 @@ const Calendar: React.FC<Props> = ({
         const isToday = isSameDay(day, new Date());
         const isNotCurrentMonth = !isSameMonth(day, currentMonth);
         const formattedDate = format(day, "yyyy-MM-dd");
-        const schedule = scheduleData.find((item) => item.date === formattedDate);
+        const schedule = scheduleData?.find((item) => item.date === formattedDate);
         const isAvailable = availableDates?.includes(formattedDate);
         const groupAvailableDate = groupAvailableDates?.find((item) => item.date === formattedDate);
 

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -1,4 +1,4 @@
-import React, { JSX, useState } from "react";
+import React, { JSX } from "react";
 import {
   addMonths,
   subMonths,
@@ -24,8 +24,8 @@ interface Props {
   availableDates?: string[];
   setAvailableDates?: React.Dispatch<React.SetStateAction<string[]>>;
   scheduleData: IGroupScheduleType[] | undefined;
-  groupAvailableDates?: IGetGroupPossibleScheduleType[];
-  setSelectedDate?: React.Dispatch<React.SetStateAction<string>>;
+  groupAvailableDates?: IGroupPossibleScheduleItemType[];
+  setSelectedDate: React.Dispatch<React.SetStateAction<string>>;
   currentMonth: Date;
   setCurrentMonth: React.Dispatch<React.SetStateAction<Date>>;
 }
@@ -38,9 +38,8 @@ const Calendar: React.FC<Props> = ({
   groupAvailableDates,
   setSelectedDate,
   currentMonth,
-  setCurrentMonth
+  setCurrentMonth,
 }) => {
-
   const handlePrevMonth = () => {
     setCurrentMonth((prev) => subMonths(prev, 1));
   };
@@ -78,7 +77,7 @@ const Calendar: React.FC<Props> = ({
     const handleDateClick = (date: string) => {
       const today = startOfDay(new Date());
       const selectedDate = startOfDay(new Date(date));
-      type === "view" && setSelectedDate!(date);
+      setSelectedDate(date);
 
       if (type === "myPossible" && !isAfter(today, selectedDate)) {
         setAvailableDates!((prev) => {
@@ -104,14 +103,14 @@ const Calendar: React.FC<Props> = ({
         if (type === "myPossible" && isAvailable) {
           backgroundColor = "#C9ACE7";
         } else if (type === "groupPossible" && groupAvailableDate) {
-          const possibleRatio = groupAvailableDate.possibleRatio;
-          if (possibleRatio >= 0 && possibleRatio <= 25) {
+          const possibleRatio = groupAvailableDate.ratio;
+          if (possibleRatio > 0 && possibleRatio <= 25) {
             backgroundColor = "var(--people-50)";
-          } else if (possibleRatio >= 26 && possibleRatio <= 50) {
+          } else if (possibleRatio > 25 && possibleRatio <= 50) {
             backgroundColor = "var(--people-100)";
-          } else if (possibleRatio >= 51 && possibleRatio <= 75) {
+          } else if (possibleRatio > 50 && possibleRatio <= 75) {
             backgroundColor = "var(--people-200)";
-          } else if (possibleRatio >= 76 && possibleRatio <= 100) {
+          } else if (possibleRatio > 75 && possibleRatio <= 100) {
             backgroundColor = "var(--people-300)";
           }
         } else if (isToday) {
@@ -122,6 +121,7 @@ const Calendar: React.FC<Props> = ({
         const isSunday = format(day, "i") === "7";
         const isClickable =
           type === "myPossible" && !isAfter(startOfDay(new Date()), startOfDay(day));
+        const isGroupClickable = type === "groupPossible";
 
         days.push(
           <div
@@ -129,7 +129,7 @@ const Calendar: React.FC<Props> = ({
             className={styles.dateCell}
             onClick={() => handleDateClick(formattedDate)}
             style={{
-              cursor: isClickable ? "pointer" : "default",
+              cursor: isClickable || isGroupClickable ? "pointer" : "default",
               color: isNotCurrentMonth ? "#767676" : isSunday || isHoliday ? "#FF0101" : "#111111",
               backgroundColor,
               borderRadius: isToday || isAvailable || groupAvailableDate ? "50%" : "0",

--- a/src/pages/GroupCalendarPage/page/index.tsx
+++ b/src/pages/GroupCalendarPage/page/index.tsx
@@ -8,60 +8,25 @@ import { useNavigate, useParams } from "react-router-dom";
 import useAuthStore from "@store/useAuthStore";
 import { useGetGroupCalendarCheckEvents } from "@api/calendar/getGroupCalendarCheckEvents";
 import { format } from "date-fns";
-
-const scheduleList: IGetScheduleListResponseBodyType = {
-  schedules: [
-    {
-      id: 1,
-      groupId: 1,
-      title: "Weekly Meeting",
-      location: "Library Room A",
-      startTime: "10:00",
-      endTime: "12:00",
-      color: "#FF5733",
-    },
-    {
-      id: 1,
-      groupId: null,
-      title: "회의 일정",
-      location: "강원 춘천시 백령로 51",
-      startTime: "10:00",
-      endTime: "12:59",
-      color: "#FFA500",
-    },
-    {
-      id: 2,
-      groupId: null,
-      title: "프로젝트 회의",
-      location: "강원 춘천시 백령로 51",
-      startTime: "13:00",
-      endTime: "15:59",
-      color: "#FFA500",
-    },
-    {
-      id: 2,
-      groupId: 1,
-      title: "Project Discussion",
-      location: "Conference Room B",
-      startTime: "14:00",
-      endTime: "15:30",
-      color: "#33FF57",
-    },
-  ],
-  birthdayPerson: ["최준혁", "김도하"],
-};
+import { useGetGroupScheduleList } from "@api/calendar/getGroupScheduleList";
+import { ko } from "date-fns/locale";
 
 const GroupCalendarPage: React.FC = () => {
   const navigate = useNavigate();
   const { groupId } = useParams<{ groupId: string }>();
   const { accessToken } = useAuthStore.getState();
+  const currentDate = new Date();
   const [currentMonth, setCurrentMonth] = useState<Date>(new Date());
+  const [selectedDate, setSelectedDate] = useState<string>(format(currentDate, "yyyy-MM-dd"));
 
   const { data: groupCheckEvents } = useGetGroupCalendarCheckEvents(
     groupId!,
     format(currentMonth, "yyyy-MM"),
     accessToken,
   );
+
+  const { data: groupScheduleList } = useGetGroupScheduleList(groupId!, accessToken, selectedDate)
+  const formattedDate = format(new Date(selectedDate), "M월 d일 (E)", { locale: ko });
 
   const handleBackArrowClick = () => {
     navigate(-1);
@@ -83,16 +48,16 @@ const GroupCalendarPage: React.FC = () => {
         handleMiniCalendarClick={handleMiniCalendarClick}
       />
       <div className={styles.calendarSection}>
-        <Calendar type="view" scheduleData={groupCheckEvents?.groupScheduleData} currentMonth={currentMonth} setCurrentMonth={setCurrentMonth}/>
+        <Calendar type="view" scheduleData={groupCheckEvents?.groupScheduleData} currentMonth={currentMonth} setCurrentMonth={setCurrentMonth} setSelectedDate={setSelectedDate} />
       </div>
       <div className={styles.content}>
         <div className={styles.scheduleSection}>
           <div className={styles.scheduleHeaderContainer}>
-            <h1 className={styles.scheduleHeader}>1월 16일 (목)</h1>
+            <h1 className={styles.scheduleHeader}>{formattedDate}</h1>
             <EditIcon className={styles.editIcon} onClick={handleGoCreateGroupSchedule} />
           </div>
           <div className={styles.cardSection}>
-            {scheduleList.schedules.map((scheduleItem) => (
+            {groupScheduleList?.schedules.map((scheduleItem) => (
               <EventCard scheduleItem={scheduleItem} />
             ))}
           </div>

--- a/src/pages/GroupCalendarPage/page/index.tsx
+++ b/src/pages/GroupCalendarPage/page/index.tsx
@@ -1,80 +1,78 @@
 import EditIcon from "@assets/Icons/myCalendar/EditIcon.svg?react";
-import React from "react";
+import React, { useState } from "react";
 import Calendar from "../../../components/calendar/Calendar";
 import CalendarHeader from "../../../components/headers/CalendarHeader";
 import styles from "./groupCalendarPage.module.scss";
 import EventCard from "@components/calendarPage/EventCard";
 import { useNavigate, useParams } from "react-router-dom";
+import useAuthStore from "@store/useAuthStore";
+import { useGetGroupCalendarCheckEvents } from "@api/calendar/getGroupCalendarCheckEvents";
+import { format } from "date-fns";
 
-interface IGetScheduleType {
-  date: string;
-  isSchedule: boolean;
-  isBirthday: boolean;
-}
-
-  const scheduleData: IGetScheduleType[] = [
-    { date: "2025-01-04", isSchedule: true, isBirthday: false },
-    { date: "2025-01-13", isSchedule: false, isBirthday: true },
-    { date: "2025-01-16", isSchedule: true, isBirthday: true },
-    { date: "2025-01-26", isSchedule: true, isBirthday: false },
-  ];
-
-  const scheduleList: IGetScheduleListResponseBodyType = {
-    schedules: [
-      {
-        id: 1,
-        groupId: 1,
-        title: "Weekly Meeting",
-        location: "Library Room A",
-        startTime: "10:00",
-        endTime: "12:00",
-        color: "#FF5733",
-      },
-      {
-        id: 1,
-        groupId: null,
-        title: "회의 일정",
-        location: "강원 춘천시 백령로 51",
-        startTime: "10:00",
-        endTime: "12:59",
-        color: "#FFA500",
-      },
-      {
-        id: 2,
-        groupId: null,
-        title: "프로젝트 회의",
-        location: "강원 춘천시 백령로 51",
-        startTime: "13:00",
-        endTime: "15:59",
-        color: "#FFA500",
-      },
-      {
-        id: 2,
-        groupId: 1,
-        title: "Project Discussion",
-        location: "Conference Room B",
-        startTime: "14:00",
-        endTime: "15:30",
-        color: "#33FF57",
-      },
-    ],
-    birthdayPerson: ["최준혁", "김도하"],
-  };
+const scheduleList: IGetScheduleListResponseBodyType = {
+  schedules: [
+    {
+      id: 1,
+      groupId: 1,
+      title: "Weekly Meeting",
+      location: "Library Room A",
+      startTime: "10:00",
+      endTime: "12:00",
+      color: "#FF5733",
+    },
+    {
+      id: 1,
+      groupId: null,
+      title: "회의 일정",
+      location: "강원 춘천시 백령로 51",
+      startTime: "10:00",
+      endTime: "12:59",
+      color: "#FFA500",
+    },
+    {
+      id: 2,
+      groupId: null,
+      title: "프로젝트 회의",
+      location: "강원 춘천시 백령로 51",
+      startTime: "13:00",
+      endTime: "15:59",
+      color: "#FFA500",
+    },
+    {
+      id: 2,
+      groupId: 1,
+      title: "Project Discussion",
+      location: "Conference Room B",
+      startTime: "14:00",
+      endTime: "15:30",
+      color: "#33FF57",
+    },
+  ],
+  birthdayPerson: ["최준혁", "김도하"],
+};
 
 const GroupCalendarPage: React.FC = () => {
   const navigate = useNavigate();
-  const {groupId} = useParams<{groupId:string}>()
+  const { groupId } = useParams<{ groupId: string }>();
+  const { accessToken } = useAuthStore.getState();
+  const [currentMonth, setCurrentMonth] = useState<Date>(new Date());
+
+  const { data: groupCheckEvents } = useGetGroupCalendarCheckEvents(
+    groupId!,
+    format(currentMonth, "yyyy-MM"),
+    accessToken,
+  );
 
   const handleBackArrowClick = () => {
     navigate(-1);
   };
   const handleMiniCalendarClick = () => {
     navigate(`/group/${groupId}/groupCalendar/possible`);
-  }
+  };
 
   const handleGoCreateGroupSchedule = () => {
     navigate(`/createSchedule/${groupId}`);
-  }
+  };
 
   return (
     <div className={styles.Container}>
@@ -85,7 +83,7 @@ const GroupCalendarPage: React.FC = () => {
         handleMiniCalendarClick={handleMiniCalendarClick}
       />
       <div className={styles.calendarSection}>
-        <Calendar type="view" scheduleData={scheduleData} />
+        <Calendar type="view" scheduleData={groupCheckEvents?.groupScheduleData} currentMonth={currentMonth} setCurrentMonth={setCurrentMonth}/>
       </div>
       <div className={styles.content}>
         <div className={styles.scheduleSection}>

--- a/src/pages/GroupCalendarPossiblePage/page/index.tsx
+++ b/src/pages/GroupCalendarPossiblePage/page/index.tsx
@@ -1,23 +1,50 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Calendar from "../../../components/calendar/Calendar";
 import CalendarHeader from "../../../components/headers/HasOnlyBackArrowHeader";
 import styles from "./groupCalendarPossible.module.scss";
 import TabComponent from "../components/TabComponent";
 import PossibleMember from "../components/PossibleMember";
+import { useParams } from "react-router-dom";
+import useAuthStore from "@store/useAuthStore";
+import { useGetGroupCalendarCheckEvents } from "@api/calendar/getGroupCalendarCheckEvents";
+import { format } from "date-fns";
+import { ko } from "date-fns/locale";
 
-interface IGetScheduleType {
-  date: string;
-  isSchedule: boolean;
-  isBirthday: boolean;
-}
+const GroupAvailableData: IGetGroupPossibleScheduleResponseBodyType = {
+  availableDateRatios: [
+    { date: "2025-02-01", ratio: 15.3333 },
+    {
+      date: "2025-02-12",
+      ratio: 27.0,
+    },
+    {
+      date: "2025-02-20",
+      ratio: 55.24,
+    },
+    {
+      date: "2025-02-28",
+      ratio: 75.9666,
+    },
+  ],
+};
 
 const GroupCalendarPossiblePage: React.FC = () => {
-  const scheduleData: IGetScheduleType[] = [
-    { date: "2025-01-04", isSchedule: true, isBirthday: false },
-    { date: "2025-01-13", isSchedule: false, isBirthday: true },
-    { date: "2025-01-16", isSchedule: true, isBirthday: true },
-    { date: "2025-01-26", isSchedule: true, isBirthday: false },
-  ];
+  const [currentMonth, setCurrentMonth] = useState<Date>(new Date());
+  const { groupId } = useParams<{ groupId: string }>();
+  const { accessToken } = useAuthStore();
+  const currentDate = new Date();
+  const [selectedDate, setSelectedDate] = useState<string>(format(currentDate, "yyyy-MM-dd"));
+   const formattedDate = format(new Date(selectedDate), "M월 d일 (E)", { locale: ko });
+
+  const { data: groupCheckEvents } = useGetGroupCalendarCheckEvents(
+    groupId!,
+    format(currentMonth, "yyyy-MM"),
+    accessToken,
+  );
+
+  useEffect(() => {
+    console.log(selectedDate);
+  }, [selectedDate])
 
   return (
     <div className={styles.Container}>
@@ -28,9 +55,16 @@ const GroupCalendarPossiblePage: React.FC = () => {
         }}
       />
       <div className={styles.ContentContainer}>
-        <Calendar type="groupPossible" scheduleData={scheduleData} />
+        <Calendar
+          type="groupPossible"
+          scheduleData={groupCheckEvents?.groupScheduleData}
+          currentMonth={currentMonth}
+          setCurrentMonth={setCurrentMonth}
+          groupAvailableDates={GroupAvailableData.availableDateRatios}
+          setSelectedDate={setSelectedDate}
+        />
         <div className={styles.InfoBox}>
-          <p className={styles.Date}>9월 19일 (목)</p>
+          <p className={styles.Date}>{formattedDate}</p>
           <PossibleMember
             possibleMembers={["이수현", "이다은", "정재호", "최준혁", "이상준", "김도하"]}
           />

--- a/src/pages/GroupPage/page/index.tsx
+++ b/src/pages/GroupPage/page/index.tsx
@@ -86,7 +86,7 @@ const GroupPage = () => {
             rightType="star"
             isPin={optimisticGroupDetails?.isPin}
             groupId={Number(groupId!)}
-            handleLeftClick={() => navigate(-1)}
+            handleLeftClick={() => navigate("/groupList")}
             handleRightClick={handlePinClick}
           />
           <div className={styles.contentContainer}>

--- a/src/pages/MyCalendarPage/page/index.tsx
+++ b/src/pages/MyCalendarPage/page/index.tsx
@@ -65,6 +65,7 @@ const scheduleList: IGetScheduleListResponseBodyType = {
 const MyCalendarPage: React.FC = () => {
   const navigate = useNavigate();
   const [selectedDate, setSelectedDate] = useState<string>("");
+  const [currentMonth, setCurrentMonth] = useState<Date>(new Date())
 
   const handleMiniCalendarClick = () => {
     navigate("/myCalendarPossible");
@@ -84,7 +85,7 @@ const MyCalendarPage: React.FC = () => {
 
       <div className={styles.content}>
         <div className={styles.calendarSection}>
-          <Calendar type="view" scheduleData={scheduleData} setSelectedDate={setSelectedDate} />
+          <Calendar type="view" scheduleData={scheduleData} setSelectedDate={setSelectedDate} currentMonth={currentMonth} setCurrentMonth={setCurrentMonth} />
         </div>
         <div className={styles.scheduleSection}>
           <div className={styles.scheduleHeaderContainer}>

--- a/src/types/calendar.d.ts
+++ b/src/types/calendar.d.ts
@@ -56,3 +56,13 @@ type IGroupScheduleType = {
   isSchedule: boolean;
   isBirthday: boolean;
 };
+
+// 그룹 달력 - 가능한 날짜 조회 Api
+type IGetGroupPossibleScheduleResponseBodyType = {
+  availableDateRatios: IGroupPossibleScheduleItemType[]
+};
+
+type IGroupPossibleScheduleItemType = {
+  date: string;
+  ratio: number;
+}

--- a/src/types/calendar.d.ts
+++ b/src/types/calendar.d.ts
@@ -45,3 +45,14 @@ type IScheduleItemType = {
   id: number;
   color: string;
 }
+
+// 그룹 달력 일정 유무 조회 api - 그룹 달력 페이지
+type IGetGroupCalendarCheckEventsResponseBodyType = {
+  groupScheduleData: IGroupScheduleType[]
+}
+
+type IGroupScheduleType = {
+  date: string;
+  isSchedule: boolean;
+  isBirthday: boolean;
+};

--- a/src/types/get.d.ts
+++ b/src/types/get.d.ts
@@ -1,8 +1,4 @@
-type IGetScheduleType = {
-  date: string;
-  isSchedule: boolean;
-  isBirthday: boolean;
-};
+
 
 type IGetGroupPossibleScheduleType = {
   date: string;

--- a/src/types/get.d.ts
+++ b/src/types/get.d.ts
@@ -1,10 +1,3 @@
-
-
-type IGetGroupPossibleScheduleType = {
-  date: string;
-  possibleRatio: number;
-};
-
 //가능한 날짜
 type IGetAvailableMemberInfoType = {
   memberName: string;


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #148 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

> 1. 그룹 달력 관련 페이지에서 받아오는 데이터 타입 정의
> 2. 그룹 달력 일정 조회 api 연동
> 3. 그룹 일정 유무 조회 api 연동

## 📝수정 내용(선택)
> 1. 달력 페이지에서 사용되는 달력 컴포넌트 로직 수정 
> 2. 그룹 가능한 날짜 보기 페이지 로직 수정 및 목업 데이터 생성
> 3. 달력 페이지에서 사용되는 달력 컴포넌트 로직 수정 및 그룹 달력 페이지 Api 연동


### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 1. 생일자 카드 컴포넌트는 디자인 나오면 만들게요
> 2. 백엔드 로직 수정하고 머지되면 제대로 보일거에요
