### PR TITLE
Feat: 실시간 알림 일괄읽음 처리 api 연동 및 백엔드 api 수정에 따른 로직 수정

### DIFF
--- a/src/api/apiRoutes.ts
+++ b/src/api/apiRoutes.ts
@@ -32,7 +32,8 @@ const apiRoutes = {
   chatRoomsList: "/chats",
   // 알림 관련
   readNotification: "/notification/read",
-  notificationList: "/notification/list"
+  notificationList: "/notification/list",
+  readAllNotifications: "/notification/read-all",
 };
 
 export default apiRoutes;

--- a/src/api/notification/getSubscribeToSSE.ts
+++ b/src/api/notification/getSubscribeToSSE.ts
@@ -58,7 +58,6 @@ export const getSubscribeToSSE = async (accessToken: string, queryClient: QueryC
                 "GROUP_LIST",
                 "GROUP_INVITE_LIST",
                 "GROUP_MEMBER_LIST",
-                "FRIEND_LIST",
                 "GROUP_MEMBER_INVITE_LIST",
               ].forEach((key) =>
                 queryClient.invalidateQueries({
@@ -86,6 +85,20 @@ export const getSubscribeToSSE = async (accessToken: string, queryClient: QueryC
               queryClient.invalidateQueries({
                 queryKey: ["COMMENT_LIST"],
               });
+            }
+
+            if (parsedData.eventType === "GROUP_INVITATION_CANCELLED") {
+              queryClient.invalidateQueries({
+                queryKey: ["GROUP_INVITE_LIST"],
+              });
+            }
+
+            if (parsedData.eventType === "GROUP_MEMBER_LEFT") {
+              ["GROUP_MEMBER_INVITE_LIST", "GROUP_MEMBER_LIST"].forEach((key) =>
+                queryClient.invalidateQueries({
+                  queryKey: [key],
+                }),
+              );
             }
 
             queryClient.invalidateQueries({

--- a/src/api/notification/postReadAllNotifications.ts
+++ b/src/api/notification/postReadAllNotifications.ts
@@ -1,0 +1,23 @@
+import apiRoutes from "@api/apiRoutes"
+import api from "@api/fetcher"
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+const postReadAllNotifications = async (authorization: string) => {
+    const response: IResponseType = await api.post({
+        endpoint: apiRoutes.readAllNotifications,
+        authorization
+    })
+    return response;
+}
+
+export const usePostReadAllNotifications = (authorization: string) => {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: () => postReadAllNotifications(authorization),
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: ["NOTIFICATION_LIST"]
+            })
+        }
+    })
+}

--- a/src/components/headers/HasOnlyBackArrowHeader.tsx
+++ b/src/components/headers/HasOnlyBackArrowHeader.tsx
@@ -2,14 +2,21 @@ import React from "react";
 import styles from "./hasOnlyBackArrowHeader.module.scss";
 import BackArrow1_Icon from "@assets/Icons/headers/backArrow1.svg?react";
 import BackArrow2_Icon from "@assets/Icons/headers/backArrow2.svg?react";
+import MiniButton from "@components/buttons/MiniButton";
 
 interface Props {
   title: string;
   pageType?: "login" | string;
   handleClick: () => void;
+  handleReadAllClick?: () => void;
 }
 
-const HasOnlyBackArrowHeader: React.FC<Props> = ({ title, handleClick, pageType }) => {
+const HasOnlyBackArrowHeader: React.FC<Props> = ({
+  title,
+  handleClick,
+  pageType,
+  handleReadAllClick,
+}) => {
   return (
     <div className={styles.mainContainer}>
       <div className={styles.iconSection} onClick={handleClick}>
@@ -20,6 +27,9 @@ const HasOnlyBackArrowHeader: React.FC<Props> = ({ title, handleClick, pageType 
         )}
       </div>
       <div className={styles.titleSection}>{title}</div>
+      {title === "알림" && (
+        <MiniButton buttonText="모두 읽음" color="purple_light" onClick={handleReadAllClick} />
+      )}
     </div>
   );
 };

--- a/src/components/headers/HasOnlyBackArrowHeader.tsx
+++ b/src/components/headers/HasOnlyBackArrowHeader.tsx
@@ -28,7 +28,7 @@ const HasOnlyBackArrowHeader: React.FC<Props> = ({
       </div>
       <div className={styles.titleSection}>{title}</div>
       {title === "알림" && (
-        <MiniButton buttonText="모두 읽음" color="purple_light" onClick={handleReadAllClick} />
+        <MiniButton buttonText="모두 읽기" color="purple_light" onClick={handleReadAllClick} />
       )}
     </div>
   );

--- a/src/components/headers/hasOnlyBackArrowHeader.module.scss
+++ b/src/components/headers/hasOnlyBackArrowHeader.module.scss
@@ -10,6 +10,7 @@
   z-index: 50;
   position: sticky;
   top: 0;
+  justify-content: space-between;
 
   .iconSection {
     cursor: pointer;

--- a/src/pages/NotificationPage/page/index.tsx
+++ b/src/pages/NotificationPage/page/index.tsx
@@ -2,6 +2,8 @@ import HasOnlyBackArrowHeader from "@components/headers/HasOnlyBackArrowHeader";
 import styles from "./notification.module.scss";
 import { useNavigate, useOutletContext } from "react-router-dom";
 import NotificationList from "../components/NotificationList";
+import { usePostReadAllNotifications } from "@api/notification/postReadAllNotifications";
+import useAuthStore from "@store/useAuthStore";
 
 const NotificationPage = () => {
   const { notifications, isLoading, error } = useOutletContext<{
@@ -10,21 +12,27 @@ const NotificationPage = () => {
     error: Error | null;
   }>();
   const navigate = useNavigate();
+  const { accessToken } = useAuthStore.getState();
+  const { mutate: readAllNotifications } = usePostReadAllNotifications(accessToken);
 
   const sortedNotificationList = notifications.notificationList.sort((a, b) => {
     return new Date(b.createdDate).getTime() - new Date(a.createdDate).getTime();
-    })
+  });
 
   if (isLoading) {
-    return <div>로딩중...</div>
+    return <div>로딩중...</div>;
   }
   if (error) {
-    return <div>오류 발생 : {error.message}</div>
+    return <div>오류 발생 : {error.message}</div>;
   }
 
   return (
     <div className={styles.mainContainer}>
-      <HasOnlyBackArrowHeader title="알림" handleClick={() => navigate(-1)} />
+      <HasOnlyBackArrowHeader
+        title="알림"
+        handleClick={() => navigate(-1)}
+        handleReadAllClick={readAllNotifications}
+      />
       <NotificationList notificationList={sortedNotificationList} />
     </div>
   );

--- a/src/types/notification.d.ts
+++ b/src/types/notification.d.ts
@@ -16,7 +16,9 @@ type INotificationItemType = {
     | "GROUP_EXPEL"
     | "GROUP_SCHEDULE_DELETE"
     | "GROUP_SCHEDULE_CREATE"
-    | "COMMENT";
+    | "COMMENT"
+    | "GROUP_INVITATION_CANCELLED"
+    | "GROUP_MEMBER_LEFT";
   contents: string;
   read: boolean;
   relatedUrl: string;


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #177 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

> 1. 그룹 초대 취소, 그룹원 초대 알림에 따른 쿼리무효 로직 추가
> 2. 알림 전체 읽기 api 연동 로직 작성
> 3. 알림 페이지 헤더에 "모두읽기"버튼 추가

## 📝수정 내용(선택)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> - 지금 서버 연결에 문제가 생겨서 로직만 짜둔 상태고 해결되면 테스트해보고 버튼도 다시 퍼블리싱할게여
