### PR TITLE
Feat: 카카오 로그인 연동

### DIFF
--- a/src/api/apiRoutes.ts
+++ b/src/api/apiRoutes.ts
@@ -32,7 +32,8 @@ const apiRoutes = {
   chatRoomsList: "/chats",
   // 알림 관련
   readNotification: "/notification/read",
-  notificationList: "/notification/list"
+  notificationList: "/notification/list",
+  readAllNotifications: "/notification/read-all",
 };
 
 export default apiRoutes;

--- a/src/api/notification/getSubscribeToSSE.ts
+++ b/src/api/notification/getSubscribeToSSE.ts
@@ -58,7 +58,6 @@ export const getSubscribeToSSE = async (accessToken: string, queryClient: QueryC
                 "GROUP_LIST",
                 "GROUP_INVITE_LIST",
                 "GROUP_MEMBER_LIST",
-                "FRIEND_LIST",
                 "GROUP_MEMBER_INVITE_LIST",
               ].forEach((key) =>
                 queryClient.invalidateQueries({
@@ -86,6 +85,20 @@ export const getSubscribeToSSE = async (accessToken: string, queryClient: QueryC
               queryClient.invalidateQueries({
                 queryKey: ["COMMENT_LIST"],
               });
+            }
+
+            if (parsedData.eventType === "GROUP_INVITATION_CANCELLED") {
+              queryClient.invalidateQueries({
+                queryKey: ["GROUP_INVITE_LIST"],
+              });
+            }
+
+            if (parsedData.eventType === "GROUP_MEMBER_LEFT") {
+              ["GROUP_MEMBER_INVITE_LIST", "GROUP_MEMBER_LIST"].forEach((key) =>
+                queryClient.invalidateQueries({
+                  queryKey: [key],
+                }),
+              );
             }
 
             queryClient.invalidateQueries({

--- a/src/api/notification/postReadAllNotifications.ts
+++ b/src/api/notification/postReadAllNotifications.ts
@@ -1,0 +1,23 @@
+import apiRoutes from "@api/apiRoutes"
+import api from "@api/fetcher"
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+const postReadAllNotifications = async (authorization: string) => {
+    const response: IResponseType = await api.post({
+        endpoint: apiRoutes.readAllNotifications,
+        authorization
+    })
+    return response;
+}
+
+export const usePostReadAllNotifications = (authorization: string) => {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: () => postReadAllNotifications(authorization),
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: ["NOTIFICATION_LIST"]
+            })
+        }
+    })
+}

--- a/src/components/headers/HasOnlyBackArrowHeader.tsx
+++ b/src/components/headers/HasOnlyBackArrowHeader.tsx
@@ -2,14 +2,21 @@ import React from "react";
 import styles from "./hasOnlyBackArrowHeader.module.scss";
 import BackArrow1_Icon from "@assets/Icons/headers/backArrow1.svg?react";
 import BackArrow2_Icon from "@assets/Icons/headers/backArrow2.svg?react";
+import MiniButton from "@components/buttons/MiniButton";
 
 interface Props {
   title: string;
   pageType?: "login" | string;
   handleClick: () => void;
+  handleReadAllClick?: () => void;
 }
 
-const HasOnlyBackArrowHeader: React.FC<Props> = ({ title, handleClick, pageType }) => {
+const HasOnlyBackArrowHeader: React.FC<Props> = ({
+  title,
+  handleClick,
+  pageType,
+  handleReadAllClick,
+}) => {
   return (
     <div className={styles.mainContainer}>
       <div className={styles.iconSection} onClick={handleClick}>
@@ -20,6 +27,9 @@ const HasOnlyBackArrowHeader: React.FC<Props> = ({ title, handleClick, pageType 
         )}
       </div>
       <div className={styles.titleSection}>{title}</div>
+      {title === "알림" && (
+        <MiniButton buttonText="모두 읽음" color="purple_light" onClick={handleReadAllClick} />
+      )}
     </div>
   );
 };

--- a/src/components/headers/HasOnlyBackArrowHeader.tsx
+++ b/src/components/headers/HasOnlyBackArrowHeader.tsx
@@ -28,7 +28,7 @@ const HasOnlyBackArrowHeader: React.FC<Props> = ({
       </div>
       <div className={styles.titleSection}>{title}</div>
       {title === "알림" && (
-        <MiniButton buttonText="모두 읽음" color="purple_light" onClick={handleReadAllClick} />
+        <MiniButton buttonText="모두 읽기" color="purple_light" onClick={handleReadAllClick} />
       )}
     </div>
   );

--- a/src/components/headers/hasOnlyBackArrowHeader.module.scss
+++ b/src/components/headers/hasOnlyBackArrowHeader.module.scss
@@ -10,6 +10,7 @@
   z-index: 50;
   position: sticky;
   top: 0;
+  justify-content: space-between;
 
   .iconSection {
     cursor: pointer;

--- a/src/pages/LoginPage/page/index.tsx
+++ b/src/pages/LoginPage/page/index.tsx
@@ -34,6 +34,10 @@ const LoginPage: React.FC = () => {
     },
   });
 
+  const handleKakaoLoginClick = () => {
+    window.location.href = `${import.meta.env.VITE_KAKAO_LOGIN_URL}`
+  }
+
   useEffect(() => {
     const savedId = localStorage.getItem("userStoredId");
     if (savedId) {
@@ -97,7 +101,7 @@ const LoginPage: React.FC = () => {
     } catch (error) {
       // 백엔드에서 에러처리 해주면 다시 에러핸들링 해야함
       console.error("로그인 실패:", error);
-      alert("ID와 Password를 다시 확인하세요");
+      alert(error);
     }
   };
 
@@ -135,9 +139,7 @@ const LoginPage: React.FC = () => {
         <LoginButton buttonType="login" onClick={handleSubmit(onSubmit)} />
         <LoginButton
           buttonType="login_kakao_white"
-          onClick={() => {
-            return;
-          }}
+          onClick={handleKakaoLoginClick}
         />
       </div>
       <GoLogin textType="register" textColor="gray" />

--- a/src/pages/MyCalendarPage/page/index.tsx
+++ b/src/pages/MyCalendarPage/page/index.tsx
@@ -73,7 +73,7 @@ const MyCalendarPage: React.FC = () => {
   const formattedDate = format(new Date(selectedDate), "M월 d일 (E)", { locale: ko });
 
   const handleMiniCalendarClick = () => {
-    navigate("/myCalendarPossible");
+    navigate("/myCalendar/possible");
   };
 
   return (

--- a/src/pages/MyCalendarPossiblePage/page/index.tsx
+++ b/src/pages/MyCalendarPossiblePage/page/index.tsx
@@ -5,8 +5,8 @@ import CalendarHeader from "../../../components/headers/HasOnlyBackArrowHeader";
 import Footer from "../../../components/nav-bar/BottomNavBar";
 import styles from "./myCalendarPossible.module.scss";
 import EventCard from "@components/calendarPage/EventCard";
-import useAuthStore from "@store/useAuthStore";
-import { postReissue } from "@api/user/postReissue";
+import { format } from "date-fns";
+import { useNavigate } from "react-router-dom";
 
 interface IGetScheduleType {
   date: string;
@@ -16,22 +16,11 @@ interface IGetScheduleType {
 
 const MyCalendarPossiblePage: React.FC = () => {
   const [availableDates, setAvailableDates] = useState<string[]>([]);
+  const navigate = useNavigate();
   const [isEditing, setIsEditing] = useState(false);
-  const { accessToken } = useAuthStore.getState();
-  useEffect(() => {
-    const reissueToken = async () => {
-      if (!accessToken) {
-        const newAccessToken = await postReissue();
-        if (newAccessToken) {
-          useAuthStore.setState({
-            isLogin: true,
-            accessToken: newAccessToken,
-          });
-        }
-      }
-    };
-    reissueToken();
-  }, [accessToken]);
+  const currentDate = new Date();
+  const [currentMonth, setCurrentMonth] = useState<Date>(new Date());
+  const [selectedDate, setSelectedDate] = useState<string>(format(currentDate, "yyyy-MM-dd"));
 
   const scheduleData: IGetScheduleType[] = [
     { date: "2025-01-04", isSchedule: true, isBirthday: false },
@@ -47,7 +36,7 @@ const MyCalendarPossiblePage: React.FC = () => {
       <CalendarHeader
         title="가능한 날짜 선택"
         handleClick={() => {
-          return;
+          navigate(-1);
         }}
       />
 
@@ -58,22 +47,35 @@ const MyCalendarPossiblePage: React.FC = () => {
             availableDates={availableDates}
             setAvailableDates={setAvailableDates}
             scheduleData={scheduleData}
+            setSelectedDate={setSelectedDate}
+            currentMonth={currentDate}
+            setCurrentMonth={setCurrentMonth}
           />
         </div>
         <div className={styles.scheduleSection}>
           <div className={styles.scheduleHeader}>1월 12일 (일)</div>
           <div className={styles.subText}>오늘 나의 스케줄</div>
           <EventCard
-            time="08:00 ~ 12:00"
-            title="새벽 등산 3km 왕복 달리기/ 걷기"
-            location="제주 서귀포시 토평동 산 15-1"
-            timeColor="var(--violet-350)"
+            scheduleItem={{
+              startTime: "08:00",
+              endTime: "12:00",
+              title: "새벽 등산 3km 왕복 달리기/ 걷기",
+              location: "제주 서귀포시 토평동 산 15-1",
+              color: "var(--violet-350)",
+              groupId: "",
+              id: 1,
+            }}
           />
           <EventCard
-            time="15:00 ~ 17:00"
-            title="컴퓨터 수업 듣고 친구 만나기"
-            location="강원 춘천시 효자동 768-4"
-            timeColor="var(--violet-400)"
+            scheduleItem={{
+              startTime: "15:00",
+              endTime: "21:00",
+              title: "컴퓨터 수업 듣고 친구 만나기",
+              location: "강원 춘천시 효자동 768-4",
+              color: "var(--violet-400)",
+              groupId: "",
+              id: 2,
+            }}
           />
         </div>
         <div className={styles.editButton}>

--- a/src/pages/MyCalendarPossiblePage/page/index.tsx
+++ b/src/pages/MyCalendarPossiblePage/page/index.tsx
@@ -1,10 +1,12 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import EditButton from "../../../components/buttons/DefaultButton";
 import Calendar from "../../../components/calendar/Calendar";
 import CalendarHeader from "../../../components/headers/HasOnlyBackArrowHeader";
 import Footer from "../../../components/nav-bar/BottomNavBar";
 import styles from "./myCalendarPossible.module.scss";
 import EventCard from "@components/calendarPage/EventCard";
+import useAuthStore from "@store/useAuthStore";
+import { postReissue } from "@api/user/postReissue";
 
 interface IGetScheduleType {
   date: string;
@@ -15,6 +17,21 @@ interface IGetScheduleType {
 const MyCalendarPossiblePage: React.FC = () => {
   const [availableDates, setAvailableDates] = useState<string[]>([]);
   const [isEditing, setIsEditing] = useState(false);
+  const { accessToken } = useAuthStore.getState();
+  useEffect(() => {
+    const reissueToken = async () => {
+      if (!accessToken) {
+        const newAccessToken = await postReissue();
+        if (newAccessToken) {
+          useAuthStore.setState({
+            isLogin: true,
+            accessToken: newAccessToken,
+          });
+        }
+      }
+    };
+    reissueToken();
+  }, [accessToken]);
 
   const scheduleData: IGetScheduleType[] = [
     { date: "2025-01-04", isSchedule: true, isBirthday: false },

--- a/src/pages/MyCalendarPossiblePage/page/myCalendarPossible.module.scss
+++ b/src/pages/MyCalendarPossiblePage/page/myCalendarPossible.module.scss
@@ -25,6 +25,9 @@
 
 .scheduleSection {
   padding: 0 20px;
+  display:flex;
+  flex-direction: column;
+  gap: 20px;
 
   .scheduleHeader {
     font-size: 19px;
@@ -40,4 +43,5 @@
   display: flex;
   justify-content: center;
   padding: 10px 0;
+  margin-top: 10px;
 }

--- a/src/pages/NotificationPage/page/index.tsx
+++ b/src/pages/NotificationPage/page/index.tsx
@@ -2,6 +2,8 @@ import HasOnlyBackArrowHeader from "@components/headers/HasOnlyBackArrowHeader";
 import styles from "./notification.module.scss";
 import { useNavigate, useOutletContext } from "react-router-dom";
 import NotificationList from "../components/NotificationList";
+import { usePostReadAllNotifications } from "@api/notification/postReadAllNotifications";
+import useAuthStore from "@store/useAuthStore";
 
 const NotificationPage = () => {
   const { notifications, isLoading, error } = useOutletContext<{
@@ -10,21 +12,27 @@ const NotificationPage = () => {
     error: Error | null;
   }>();
   const navigate = useNavigate();
+  const { accessToken } = useAuthStore.getState();
+  const { mutate: readAllNotifications } = usePostReadAllNotifications(accessToken);
 
   const sortedNotificationList = notifications.notificationList.sort((a, b) => {
     return new Date(b.createdDate).getTime() - new Date(a.createdDate).getTime();
-    })
+  });
 
   if (isLoading) {
-    return <div>로딩중...</div>
+    return <div>로딩중...</div>;
   }
   if (error) {
-    return <div>오류 발생 : {error.message}</div>
+    return <div>오류 발생 : {error.message}</div>;
   }
 
   return (
     <div className={styles.mainContainer}>
-      <HasOnlyBackArrowHeader title="알림" handleClick={() => navigate(-1)} />
+      <HasOnlyBackArrowHeader
+        title="알림"
+        handleClick={() => navigate(-1)}
+        handleReadAllClick={readAllNotifications}
+      />
       <NotificationList notificationList={sortedNotificationList} />
     </div>
   );

--- a/src/pages/StartPage/index.tsx
+++ b/src/pages/StartPage/index.tsx
@@ -8,6 +8,10 @@ import styles from "./startPage.module.scss";
 const StartPage: React.FC = () => {
   const navigate = useNavigate();
 
+  const handleKakaoLoginClick = () => {
+    window.location.href = `${import.meta.env.VITE_KAKAO_LOGIN_URL}`;
+  };
+
   return (
     <div className={styles.Container}>
       <div className={styles.LogoBox}></div>
@@ -16,9 +20,7 @@ const StartPage: React.FC = () => {
       <div className={styles.ButtonBox}>
         <LoginButton
           buttonType="login_kakao"
-          onClick={() => {
-            return;
-          }}
+          onClick={handleKakaoLoginClick}
         />
         <LoginButton
           buttonType="login_other"

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
 import useAuthStore from "@store/useAuthStore";
 import useBottomStore from "@store/useBottomStore";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Navigate, Outlet, useLocation } from "react-router-dom";
 import {
   BOTTOM_INDEX_0,
@@ -11,15 +11,33 @@ import {
 import { getSubscribeToSSE } from "@api/notification/getSubscribeToSSE";
 import { useQueryClient } from "@tanstack/react-query";
 import { useGetNotificationList } from "@api/notification/getNotificationList";
+import { postReissue } from "@api/user/postReissue";
 
 const ProtectedRoute = () => {
-  const { accessToken } = useAuthStore();
+  const { accessToken, setAccessToken, setIsLogin } = useAuthStore();
   const intervalRef = useRef<number | null>(null);
   const queryClient = useQueryClient();
   const location = useLocation();
   const { setBottomIndex } = useBottomStore();
+  const [isReissuing, setIsReissuing] = useState<boolean>(true);
 
   const { data: notifications, isLoading, error } = useGetNotificationList(accessToken);
+
+  useEffect(() => {
+    const reissueToken = async () => {
+      if (!accessToken) {
+        try {
+          const newAccessToken = await postReissue();
+          setIsLogin(true);
+          setAccessToken(newAccessToken);
+        } catch (error) {
+          console.error("토큰 재발급 실패: ", error);
+        }
+      }
+      setIsReissuing(false);
+    };
+    reissueToken();
+  }, []);
 
   useEffect(() => {
     if (!accessToken) {
@@ -29,17 +47,20 @@ const ProtectedRoute = () => {
     getSubscribeToSSE(accessToken, queryClient);
 
     // 1시간마다 SSE 자동 재연결
-    intervalRef.current = window.setInterval(() => {
-      console.log("🔄 SSE 자동 재연결 중...");
-      getSubscribeToSSE(accessToken, queryClient);
-    }, 60 * 60 * 1000);
+    intervalRef.current = window.setInterval(
+      () => {
+        console.log("🔄 SSE 자동 재연결 중...");
+        getSubscribeToSSE(accessToken, queryClient);
+      },
+      60 * 60 * 1000,
+    );
 
     return () => {
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
       }
-    }
-  }, [accessToken])
+    };
+  }, [accessToken]);
 
   useEffect(() => {
     const currentPath = location.pathname;
@@ -54,10 +75,14 @@ const ProtectedRoute = () => {
     }
   }, [location.pathname]);
 
+  if (isReissuing) {
+    return null;
+  }
+
   if (!accessToken) {
     return <Navigate to="/" replace />;
   }
-  return <Outlet context={{notifications, isLoading, error}}/>;
+  return <Outlet context={{ notifications, isLoading, error }} />;
 };
 
 export default ProtectedRoute;

--- a/src/types/notification.d.ts
+++ b/src/types/notification.d.ts
@@ -16,7 +16,9 @@ type INotificationItemType = {
     | "GROUP_EXPEL"
     | "GROUP_SCHEDULE_DELETE"
     | "GROUP_SCHEDULE_CREATE"
-    | "COMMENT";
+    | "COMMENT"
+    | "GROUP_INVITATION_CANCELLED"
+    | "GROUP_MEMBER_LEFT";
   contents: string;
   read: boolean;
   relatedUrl: string;


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #176 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

> 1. 카카오 로그인을 위해 accessToken이 필수인 페이지가 렌더링 되기전 감싸고 있는 ProtectedRouted에서 accessToken이 없을시 reissue api를 호출해 성공응답을 받으면 isLogin, accessToken을 재설정 후 로컬에 저장하고, 해당 페이지 렌더링이 완료되도록 하는 로직 추가
> 2. 카카오 로그인 버튼에 카카오 로그인 Url로 이동하는 로직 추가

## 📝수정 내용(선택)
> 1. 나의 달력, 가능한 나의 달력 페이지 로직 일부 수정(페이지 이동 등등)

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)
> - 카카오 로그인 시나리오 입니다.
> 1. 카카오 로그인 버튼 클릭 시 카카오 로그인 URL(.env파일에 정의)로 이동
> 2. 로그인 성공 시 백엔드에서 프론트 /myCalendar 페이지로 리디렉션 및 refreshToken 쿠키에 저장해줌
> 3. /myCalendar 페이지 렌더링 되기전 상위 컴포넌트인 ProtectedRoute내에서 useAuthStore.getState()해서 받아온 accessToken이 비어있는 값이면 endpoint가 /users/token/reissue인 accessToken 재발급 api를 호출
> 4. accessToken 재발급 api에서 성공응답이 오면 재발급 api 내의 로직에 따라 accessToken이 자동으로 로컬에 저장되며 isLogin: true가 된채로 다시 myCalendar 페이지가 렌더링 완료됨