### PR TITLE
Fix: 나의 달력 페이지 오류 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ function App() {
           <Route element={<ProtectedRoute />}>
             <Route path="/registerAccount" element={<RegisterAccountPage />} />
             <Route path="/notificationList" element={<NotificationPage />} />
+            <Route path="/myCalendar/:username" element={<MyCalendarPage />} />
             <Route path="/myCalendar" element={<MyCalendarPage />} />
             <Route path="/myCalendar/possible" element={<MyCalendarPossiblePage />} />
             <Route path="/group/:groupId/groupCalendar" element={<GroupCalendarPage />} />

--- a/src/api/calendar/getMyScheduleList.ts
+++ b/src/api/calendar/getMyScheduleList.ts
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 // 개인 달력 일정 조회 API
 const getMyScheduleList = async (username: string, authorization: string, selectedDate: string) => {
   const response = api.get<IGetScheduleListResponseBodyType>({
-    endpoint: `${apiRoutes.schedules}/${username}/list?startDate=${selectedDate}&endDate=${selectedDate}`,
+    endpoint: `${apiRoutes.schedules}/list/${username}?startDate=${selectedDate}&endDate=${selectedDate}`,
     authorization,
   });
   return response;

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -23,7 +23,7 @@ interface Props {
   type: "view" | "myPossible" | "groupPossible";
   availableDates?: string[];
   setAvailableDates?: React.Dispatch<React.SetStateAction<string[]>>;
-  scheduleData: IGroupScheduleType[] | undefined;
+  scheduleData: IScheduleType[] | undefined;
   groupAvailableDates?: IGroupAvailableDatesCalendarItemType[];
   setSelectedDate: React.Dispatch<React.SetStateAction<string>>;
   currentMonth: Date;
@@ -138,7 +138,9 @@ const Calendar: React.FC<Props> = ({
           >
             {format(day, "d")}
             <div className={styles.icons}>
-              {schedule?.isSchedule && <IsScheduleIcon width={6} height={6} />}
+              {(schedule?.isSchedule || schedule?.isGroupSchedule) && (
+                <IsScheduleIcon width={6} height={6} />
+              )}
               {schedule?.isBirthday && <IsBirthdayIcon width={6} height={6} />}
             </div>
           </div>,

--- a/src/pages/FriendManagementPage/components/MemberCard.tsx
+++ b/src/pages/FriendManagementPage/components/MemberCard.tsx
@@ -5,6 +5,7 @@ import { usePostAcceptRequestFriend } from "@api/friend/postAcceptRequestFriend"
 import MiniButton from "@components/buttons/MiniButton";
 import useAuthStore from "@store/useAuthStore";
 import styles from "./memberCard.module.scss";
+import { useNavigate } from "react-router-dom";
 
 interface Props {
   memberInfo: IFriendItemType;
@@ -24,8 +25,11 @@ const MemberCard: React.FC<Props> = ({
   const { mutate: acceptRequestFriend } = usePostAcceptRequestFriend(accessToken);
   const { mutate: rejectRequestFriend } = useDeleteRejectRequestFriend(accessToken);
   const { mutate: deleteFriend } = useDeleteDeleteFriends(accessToken);
+  const navigate = useNavigate();
 
-  const handleShowFriendCalendar = () => {};
+  const handleShowFriendCalendar = () => {
+    navigate(`/myCalendar/${memberInfo.username}`)
+  };
 
   const handleCancelRequestFriend = () => {
     cancelRequestFriend(memberInfo.username);

--- a/src/pages/MyCalendarPage/page/index.tsx
+++ b/src/pages/MyCalendarPage/page/index.tsx
@@ -12,52 +12,11 @@ import Calendar from "../../../components/calendar/Calendar";
 import CalendarHeader from "../../../components/headers/CalendarHeader";
 import Footer from "../../../components/nav-bar/BottomNavBar";
 import styles from "./myCalendarPage.module.scss";
-
-/*const scheduleList: IGetScheduleListResponseBodyType = {
-  schedules: [
-    {
-      id: 1,
-      groupId: 1,
-      title: "Weekly Meeting",
-      location: "Library Room A",
-      startTime: "10:00",
-      endTime: "12:00",
-      color: "#FF5733",
-    },
-    {
-      id: 2,
-      groupId: null,
-      title: "회의 일정",
-      location: "강원 춘천시 백령로 51",
-      startTime: "10:00",
-      endTime: "12:59",
-      color: "#FFA500",
-    },
-    {
-      id: 3,
-      groupId: null,
-      title: "프로젝트 회의",
-      location: "강원 춘천시 백령로 51",
-      startTime: "13:00",
-      endTime: "15:59",
-      color: "#FFA500",
-    },
-    {
-      id: 4,
-      groupId: 1,
-      title: "Project Discussion",
-      location: "Conference Room B",
-      startTime: "14:00",
-      endTime: "15:30",
-      color: "#33FF57",
-    },
-  ],
-  birthdayPerson: ["최준혁", "김도하"],
-};*/
+import { useGetUserInfo } from "@api/user/getUserInfo";
 
 const MyCalendarPage: React.FC = () => {
   const navigate = useNavigate();
-  const { username } = useParams<{ username: string }>();
+  const { username } = useParams<{ username?: string }>();
   const { accessToken } = useAuthStore.getState();
   const currentDate = new Date();
 
@@ -65,13 +24,16 @@ const MyCalendarPage: React.FC = () => {
   const [currentMonth, setCurrentMonth] = useState<Date>(new Date());
   const formattedDate = format(new Date(selectedDate), "M월 d일 (E)", { locale: ko });
 
+  const { data: userInfo } = useGetUserInfo(accessToken);
+  const usernameToUse = username || userInfo?.username
   const { data: myCheckEvents } = useGetMyCalendarCheckEvents(
-    username!,
+    usernameToUse!,
     format(currentMonth, "yyyy-MM"),
     accessToken,
   );
 
-  const { data: myScheduleList } = useGetMyScheduleList(username!, accessToken, selectedDate);
+  const { data: myScheduleList } = useGetMyScheduleList(usernameToUse!, accessToken, selectedDate);
+
   const handleMiniCalendarClick = () => {
     navigate("/myCalendar/possible");
   };
@@ -81,7 +43,7 @@ const MyCalendarPage: React.FC = () => {
   return (
     <div className={styles.Container}>
       <CalendarHeader
-        title="나의 달력"
+        title={username ? `${username}님의 달력` : "나의 달력" }
         type="my"
         handleMiniCalendarClick={handleMiniCalendarClick}
       />

--- a/src/types/calendar.d.ts
+++ b/src/types/calendar.d.ts
@@ -51,10 +51,11 @@ type IGetGroupCalendarCheckEventsResponseBodyType = {
   groupScheduleData: IGroupScheduleType[];
 };
 
-type IGroupScheduleType = {
+type IScheduleType = {
   date: string;
   isSchedule: boolean;
   isBirthday: boolean;
+  isGroupSchedule?: boolean;
 };
 
 // 그룹 달력 - 가능한 날짜 조회 api
@@ -139,12 +140,5 @@ type IGetMyScheduleDetailType = {
 
 // 나의 달력 일정 유무 조회 api - 나의 달력 페이지
 type IGetMyCalendarCheckEventsResponseBodyType = {
-  myScheduleData: IMyScheduleType[];
-};
-
-type IMyScheduleType = {
-  date: string;
-  isSchedule: boolean;
-  isGroupSchedule: boolean;
-  isBirthday: boolean;
+  myScheduleData: IScheduleType[];
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #184

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

> 1. 개인 달력 보는 페이지 내친구달력과 내달력 구분하는 목적으로 라우팅 주소를 /myCalendar, /myCalendar/:username 두가지 경우로 추가하고 모두 MyCalendarPage 컴포넌트를 불러오도록 설정
> 2. 그룹 달력 일정 유무 조회, 개인 달력 일정 유무 조회 api response body type을 하나로 통일
> 3. 구 목록 페이지에서 친구 달력 보기 버튼 클릭 시 /myCalendar/:username 페이지로 이동하도록 추가
> 4. 나의 달력 페이지에서 사용자 정보 조회 api 호출 추가

## 📝수정 내용(선택)
> 1. 개인 달력 일정 조회 api endpoint 잘못된 부분 수정
> 2. 목업 데이터 삭제
> 3. url 파라미터에 username없을 시 받아온 사용자 정보의 username으로 개인 달력 일정 유무 조회 및 개인 달력 일정 조회 api 호출하도록 수정
> 4. 본인의 달력일 시 "나의 달력", 친구의 달력일시 "username님의 달력"으로 보여주도록 수정

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)
> 달력에서 일정 유무 조회로 받아온 데이터에 의해 ui가 바뀌어야하는데 안바뀌던 문제는 백엔드에서는 schedule: boolean, groupSchedule: boolean으로 보내주고 있었지만 프론트에서는 명세서에 적힌대로 isSchedule: boolean, isGroupSchedule: boolean으로 타입을 지정해주고 있었기 때문에 생긴 문제였습니다. 이건 백엔드에서 수정해주면 제대로 보일거에여
