### PR TITLE
Bug: kakao 로그인을 한 첫 사용자는 사용자 정보 등록 페이지로 안넘어가던 오류 및 몇가지 오류 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,7 +88,7 @@ function App() {
               <Route path="/registerAccount" element={<RegisterAccountPage />} />
               <Route path="/notificationList" element={<NotificationPage />} />
               <Route path="/myCalendar" element={<MyCalendarPage />} />
-              <Route path="/myCalendar/:username" element={<MyCalendarPage />} />
+              <Route path="/myCalendar/:name/:username" element={<MyCalendarPage />} />
               <Route path="/myCalendar/possible" element={<MyCalendarPossiblePage />} />
               <Route path="/group/:groupId/groupCalendar" element={<GroupCalendarPage />} />
               <Route

--- a/src/components/calendarPage/EventCard.tsx
+++ b/src/components/calendarPage/EventCard.tsx
@@ -7,9 +7,10 @@ import { useNavigate } from "react-router-dom";
 interface Props {
   scheduleItem: IScheduleItemType;
   groupId?: string;
+  isFriendEvent?: boolean;
 }
 
-const EventCard: React.FC<Props> = ({ scheduleItem, groupId }) => {
+const EventCard: React.FC<Props> = ({ scheduleItem, groupId, isFriendEvent = false }) => {
   const navigate = useNavigate();
 
   const handleShowScheduleDetail = () => {
@@ -20,9 +21,11 @@ const EventCard: React.FC<Props> = ({ scheduleItem, groupId }) => {
 
   return (
     <div className={styles.eventCard}>
-      <button className={styles.detailButton} onClick={handleShowScheduleDetail}>
-        상세보기 <ArrowIcon className={styles.icon} />
-      </button>
+      {!isFriendEvent && (
+        <button className={styles.detailButton} onClick={handleShowScheduleDetail}>
+          상세보기 <ArrowIcon className={styles.icon} />
+        </button>
+      )}
       <div className={styles.time} style={{ backgroundColor: scheduleItem.color || "#21212F" }}>
         {`${scheduleItem.startTime} ~ ${scheduleItem.endTime}`}
       </div>

--- a/src/components/headers/CalendarHeader.tsx
+++ b/src/components/headers/CalendarHeader.tsx
@@ -18,21 +18,28 @@ const CalenderHeader: React.FC<Props> = ({
 }) => {
   return (
     <div className={styles.mainContainer}>
-      {type === "group" && (
+      {type !== "my" && (
         <div className={styles.leftSection}>
-          <BackArrow2_Icon width={9} height={18} onClick={handleBackArrowClick} className={styles.backArrow} />
+          <BackArrow2_Icon
+            width={9}
+            height={18}
+            onClick={handleBackArrowClick}
+            className={styles.backArrow}
+          />
         </div>
       )}
 
       <div className={styles.titleSection}>{title}</div>
-      {type !== "friend" && <div className={styles.rightSection}>
-        <MiniCalender_Icon
-          width={27}
-          height={26}
-          onClick={handleMiniCalendarClick}
-          className={styles.miniCalendarIconSection}
-        />
-      </div>}
+      {type !== "friend" && (
+        <div className={styles.rightSection}>
+          <MiniCalender_Icon
+            width={27}
+            height={26}
+            onClick={handleMiniCalendarClick}
+            className={styles.miniCalendarIconSection}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/headers/CalendarHeader.tsx
+++ b/src/components/headers/CalendarHeader.tsx
@@ -5,7 +5,7 @@ import MiniCalender_Icon from "@assets/Icons/headers/miniCalendar.svg?react";
 
 interface Props {
   title: "그룹 달력" | "나의 달력" | string;
-  type: "my" | "group";
+  type: "my" | "group" | "friend";
   handleBackArrowClick?: () => void;
   handleMiniCalendarClick: () => void;
 }
@@ -25,14 +25,14 @@ const CalenderHeader: React.FC<Props> = ({
       )}
 
       <div className={styles.titleSection}>{title}</div>
-      <div className={styles.rightSection}>
+      {type !== "friend" && <div className={styles.rightSection}>
         <MiniCalender_Icon
           width={27}
           height={26}
           onClick={handleMiniCalendarClick}
           className={styles.miniCalendarIconSection}
         />
-      </div>
+      </div>}
     </div>
   );
 };

--- a/src/pages/FriendManagementPage/components/MemberCard.tsx
+++ b/src/pages/FriendManagementPage/components/MemberCard.tsx
@@ -28,7 +28,7 @@ const MemberCard: React.FC<Props> = ({
   const navigate = useNavigate();
 
   const handleShowFriendCalendar = () => {
-    navigate(`/myCalendar/${memberInfo.username}`)
+    navigate(`/myCalendar/${memberInfo.name}/${memberInfo.username}`)
   };
 
   const handleCancelRequestFriend = () => {

--- a/src/pages/MyCalendarPage/page/index.tsx
+++ b/src/pages/MyCalendarPage/page/index.tsx
@@ -18,7 +18,7 @@ import { usePostUserLocationUpdate } from "@api/user/postUserLocationUpdate";
 
 const MyCalendarPage: React.FC = () => {
   const navigate = useNavigate();
-  const { username } = useParams<{ username?: string }>();
+  const { username, name } = useParams<{ username?: string; name?: string }>();
   const { accessToken } = useAuthStore.getState();
   const currentDate = new Date();
   const [selectedDate, setSelectedDate] = useState<string>(format(currentDate, "yyyy-MM-dd"));
@@ -63,7 +63,7 @@ const MyCalendarPage: React.FC = () => {
   return (
     <div className={styles.Container}>
       <CalendarHeader
-        title={username ? `${username}님의 달력` : "나의 달력"}
+        title={name ? `${name}님의 달력` : "나의 달력"}
         type="my"
         handleMiniCalendarClick={handleMiniCalendarClick}
       />
@@ -83,7 +83,7 @@ const MyCalendarPage: React.FC = () => {
             <h1 className={styles.scheduleHeader}>{formattedDate}</h1>
             <EditIcon className={styles.editIcon} onClick={handleGoCreateSchedule} />
           </div>
-          <div className={styles.subText}>나의 스케줄</div>
+          <div className={styles.subText}>{name ? `${name}님의 스케줄` : "나의 스케줄"}</div>
           <div className={styles.cardSection}>
             {myScheduleList?.schedules.length === 0 &&
             myScheduleList?.birthdayPerson.length === 0 ? (

--- a/src/pages/MyCalendarPage/page/index.tsx
+++ b/src/pages/MyCalendarPage/page/index.tsx
@@ -64,7 +64,7 @@ const MyCalendarPage: React.FC = () => {
     <div className={styles.Container}>
       <CalendarHeader
         title={name ? `${name}님의 달력` : "나의 달력"}
-        type="my"
+        type={name ? "friend" : "my"}
         handleMiniCalendarClick={handleMiniCalendarClick}
       />
 
@@ -81,7 +81,7 @@ const MyCalendarPage: React.FC = () => {
         <div className={styles.scheduleSection}>
           <div className={styles.scheduleHeaderContainer}>
             <h1 className={styles.scheduleHeader}>{formattedDate}</h1>
-            <EditIcon className={styles.editIcon} onClick={handleGoCreateSchedule} />
+            {!name && <EditIcon className={styles.editIcon} onClick={handleGoCreateSchedule} />}
           </div>
           <div className={styles.subText}>{name ? `${name}님의 스케줄` : "나의 스케줄"}</div>
           <div className={styles.cardSection}>
@@ -99,6 +99,7 @@ const MyCalendarPage: React.FC = () => {
                       scheduleItem={scheduleItem}
                       key={scheduleItem.id}
                       groupId={scheduleItem.groupId}
+                      isFriendEvent={name ? true : false}
                     />
                   ))}
                 </>
@@ -107,7 +108,7 @@ const MyCalendarPage: React.FC = () => {
           </div>
         </div>
       </div>
-      <Footer />
+      {!name && <Footer />}
     </div>
   );
 };

--- a/src/pages/MyCalendarPage/page/index.tsx
+++ b/src/pages/MyCalendarPage/page/index.tsx
@@ -66,6 +66,9 @@ const MyCalendarPage: React.FC = () => {
         title={name ? `${name}님의 달력` : "나의 달력"}
         type={name ? "friend" : "my"}
         handleMiniCalendarClick={handleMiniCalendarClick}
+        handleBackArrowClick={() => {
+          name && navigate(-1);
+        }}
       />
 
       <div className={styles.content}>

--- a/src/pages/MyCalendarPage/page/index.tsx
+++ b/src/pages/MyCalendarPage/page/index.tsx
@@ -45,6 +45,15 @@ const MyCalendarPage: React.FC = () => {
 
   const { data: myScheduleList } = useGetMyScheduleList(usernameToUse!, accessToken, selectedDate);
 
+  useEffect(() => {
+    if (!userInfo) {
+      return;
+    }
+    if (!userInfo.birthday) {
+      window.location.replace(`${window.location.origin}/registerAccount`);
+    }
+  }, [userInfo]);
+
   const handleMiniCalendarClick = () => {
     navigate("/myCalendar/possible");
   };

--- a/src/pages/RegisterAccountPage/page/index.tsx
+++ b/src/pages/RegisterAccountPage/page/index.tsx
@@ -39,6 +39,12 @@ const RegisterAccountPage = () => {
   const { data: userInfo } = useGetUserInfo(accessToken);
 
   useEffect(() => {
+    if (userInfo?.birthday) {
+      window.location.replace(`${window.location.origin}/myCalendar`)
+    }
+  }, [userInfo])
+
+  useEffect(() => {
     setPostBody({
       UserProfileRequest: {
         birthDate: userBirth!,


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #200 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

> 1. 내 달력, 사용자 정보 등록 페이지에서 각각 userInfo.birthday 값을 검사하여 알맞은 페이지로 이동하도록 로직 추가

## 📝수정 내용(선택)

> 1. 친구 달력페이지 라우팅 주소 수정 및 기존의 {username}님의 달력 -> {name}님의 달력으로 수정
> 2. 친구 달력일때는 일정 생성 아이콘, 가능한 날짜 보기 아이콘, 하단 네비게이션바, 일정 상세조회 버튼 안보이도록 수정
> 3. 친구 달력 페이지 헤더에 뒤로 가기 버튼 추가

### 스크린샷 (선택)
<img width="216" alt="스크린샷 2025-04-09 오후 9 27 26" src="https://github.com/user-attachments/assets/cc99a6de-f388-43ab-94f8-e11877aba10c" />


## 💬리뷰 요구사항(선택)

