### PR TITLE
style & feat: 그룹 일정 조회 페이지에 실시간 위치 공유 페이지로 이동하는 버튼 추가 및 조건 로직 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,7 +108,8 @@ function App() {
                 <Route path="/createSchedule/:groupId" element={<CreateSchedulePage />} />
                 <Route path="/selectLocation" element={<SelectLocationPage />} />
                 <Route path="/mySchedule/:scheduleId" element={<MyScheduleDetailPage />} />
-                <Route path="/editSchedule/:scheduleId" element={<EditSchedulePage />} />
+                <Route path="/editSchedule/my/:scheduleId" element={<EditSchedulePage />} />
+                <Route path="/editSchedule/:groupId/:scheduleId" element={<EditSchedulePage />} />
                 <Route
                   path="/group/:groupId/calendar/schedule/:scheduleId"
                   element={<GroupScheduleDetailPage />}

--- a/src/components/createSchedule/Inputs.module.scss
+++ b/src/components/createSchedule/Inputs.module.scss
@@ -105,14 +105,23 @@
 }
 
 // participants
-.Done {
-  color: var(--gray-200);
-  background-color: var(--white);
-  border: 1px solid var(--gray-200);
-  border-radius: 3px;
-  width: 25px;
-  font-size: 10px;
-  cursor: pointer;
+.isSelecting {
+  display: flex;
+  flex-direction: column;
+  align-items: end;
+  .Done {
+    color: var(--white);
+    background-color: var(--violet-100);
+    border-radius: 10px;
+    width: 100%;
+    height: 27px;
+    font-size: 14px;
+    display: flex;
+    font-weight: bold;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+  }
 }
 
 // note

--- a/src/components/createSchedule/MemberBox.tsx
+++ b/src/components/createSchedule/MemberBox.tsx
@@ -52,12 +52,12 @@ const MemberBox: React.FC<props> = ({ groupId = "" }) => {
         value={participants.length === 0 ? "" : participants.map((p) => p.name).join(", ")}
       ></input>
       {isSelecting && (
-        <>
+        <div className={styles.isSelecting}>
           <ParticipantsPicker groupId={groupId} creator={participants[0].username} />
           <div className={styles.Done} onClick={() => setIsSelecting(false)}>
             확인
           </div>
-        </>
+        </div>
       )}
     </div>
   );

--- a/src/components/scheduleDetail/Boxes.module.scss
+++ b/src/components/scheduleDetail/Boxes.module.scss
@@ -90,9 +90,9 @@
       display: flex;
       flex-direction: column;
       border-radius: 5px;
-      font-size: 6px;
+      font-size: 12px;
       align-items: center;
-      padding-top: 2px;
+      justify-content: center;
     }
   }
   .MapBox {

--- a/src/components/scheduleDetail/LocationBox.tsx
+++ b/src/components/scheduleDetail/LocationBox.tsx
@@ -1,17 +1,45 @@
 import React, { useEffect, useState } from "react";
 import styles from "./Boxes.module.scss";
 import Icon_location from "@assets/Icons/scheduleDetail/Icon_location.svg?react";
-import Icon_arrow from "@assets/Icons/arrow/Icon_Arrow_upRight.svg?react";
 import Map from "@components/map/Map";
 import useLocationInfoStore from "@store/useLocationInfoStore";
+import { useNavigate } from "react-router-dom";
+import { differenceInHours, isSameDay, parse } from "date-fns";
+import toast from "react-hot-toast";
 
-const LocationBox: React.FC = () => {
+interface Props{
+  scheduleId?: string;
+  groupId?: string;
+  startDate?: string;
+}
+
+const LocationBox: React.FC<Props> = ({scheduleId, groupId, startDate}) => {
   const { lat, lng, name, location } = useLocationInfoStore();
   const [locationName, setLocationName] = useState<string>("");
+  const navigate = useNavigate();
 
   useEffect(() => {
     setLocationName(name ?? location);
   }, [name, location]);
+
+  const handleGoSharingLocationClick = () => {
+    const startDateTime = parse(startDate!, "yyyy-MM-dd HH:mm:ss", new Date());
+    const now = new Date();
+
+    if (isSameDay(now, startDateTime)) {
+      const diffInHours = differenceInHours(now, startDateTime);
+      if (diffInHours >= -1 && diffInHours <= 1) {
+         navigate(`/group/${groupId}/calendar/schedule/${scheduleId}/locationSharing`);
+      }
+      else {
+        toast.error("위치 현황 공유는 시작시간 ± 1시간 이내에만 가능합니다");
+      }
+    }
+    else {
+      toast.error("위치 현황 공유는 시작시간 ± 1시간 이내에만 가능합니다");
+    }
+   
+  }
 
   return (
     <div className={styles.LocationBox}>
@@ -20,9 +48,9 @@ const LocationBox: React.FC = () => {
           <Icon_location />
           <p>{locationName}</p>
         </div>
-        <div className={styles.FindRoadContainer}>
-          <Icon_arrow />
-          <p>길찾기</p>
+        <div className={styles.FindRoadContainer} onClick={handleGoSharingLocationClick}>
+          <p>위치</p>
+          <p>현황</p>
         </div>
       </div>
       <div className={styles.MapBox}>

--- a/src/components/scheduleDetail/LocationBox.tsx
+++ b/src/components/scheduleDetail/LocationBox.tsx
@@ -7,13 +7,13 @@ import { useNavigate } from "react-router-dom";
 import { differenceInHours, isSameDay, parse } from "date-fns";
 import toast from "react-hot-toast";
 
-interface Props{
+interface Props {
   scheduleId?: string;
   groupId?: string;
   startDate?: string;
 }
 
-const LocationBox: React.FC<Props> = ({scheduleId, groupId, startDate}) => {
+const LocationBox: React.FC<Props> = ({ scheduleId, groupId, startDate }) => {
   const { lat, lng, name, location } = useLocationInfoStore();
   const [locationName, setLocationName] = useState<string>("");
   const navigate = useNavigate();
@@ -29,29 +29,28 @@ const LocationBox: React.FC<Props> = ({scheduleId, groupId, startDate}) => {
     if (isSameDay(now, startDateTime)) {
       const diffInHours = differenceInHours(now, startDateTime);
       if (diffInHours >= -1 && diffInHours <= 1) {
-         navigate(`/group/${groupId}/calendar/schedule/${scheduleId}/locationSharing`);
-      }
-      else {
+        navigate(`/group/${groupId}/calendar/schedule/${scheduleId}/locationSharing`);
+      } else {
         toast.error("위치 현황 공유는 시작시간 ± 1시간 이내에만 가능합니다");
       }
-    }
-    else {
+    } else {
       toast.error("위치 현황 공유는 시작시간 ± 1시간 이내에만 가능합니다");
     }
-   
-  }
+  };
 
   return (
     <div className={styles.LocationBox}>
       <div className={styles.LocationNameBox}>
-        <div className={styles.LocationContainer}>
+        <div className={styles.LocationContainer} style={!groupId ? { width: "100%" } : undefined}>
           <Icon_location />
           <p>{locationName}</p>
         </div>
-        <div className={styles.FindRoadContainer} onClick={handleGoSharingLocationClick}>
-          <p>위치</p>
-          <p>현황</p>
-        </div>
+        {groupId && (
+          <div className={styles.FindRoadContainer} onClick={handleGoSharingLocationClick}>
+            <p>위치</p>
+            <p>현황</p>
+          </div>
+        )}
       </div>
       <div className={styles.MapBox}>
         <Map latLng={{ latitude: lat, longitude: lng }} />

--- a/src/pages/GroupScheduleDetailPage/page/index.tsx
+++ b/src/pages/GroupScheduleDetailPage/page/index.tsx
@@ -87,7 +87,7 @@ const GroupScheduleDetail: React.FC = () => {
       <div className={styles.ContentContainer}>
         <TitleBox />
         <TimeBox />
-        <LocationBox />
+        <LocationBox groupId={groupId} scheduleId={scheduleId} startDate={groupScheduleData?.startDate} />
         <ParticipantsBox />
         <MemoBox />
       </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #220 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

> 1. 실시간 위치 공유 페이지로 이동하는 버튼에 약속시작 시간이 현재시간과 비교해서 +- 1시간 이내일 경우에만 이동할 수 있도록 하는 조건문 추가

## 📝수정 내용(선택)

> 1. 그룹 일정 조회 페이지에 길찾기 버튼 -> 실시간 위치 공유 페이지로 이동하는 버튼으로 수정
> 2. App.tsx내의 일정 수정 페이지 라우팅 주소 수정

### 스크린샷 (선택)
그룹 일정 상세 조회
<img width="209" alt="스크린샷 2025-04-26 오후 3 44 40" src="https://github.com/user-attachments/assets/5fda086e-8367-4d65-8536-e55da973ab2d" />
내 일정 상세 조회
<img width="297" alt="스크린샷 2025-04-26 오후 4 45 36" src="https://github.com/user-attachments/assets/4d077277-a3d8-401f-ad4d-4177341c43a3" />

## 💬리뷰 요구사항(선택)
> - 내 일정 상세 조회에서는 위치 현황 버튼을 아예 삭제하고 그룹 일정 상세 조회 페이지에서만 보이도록 했습니다

