### PR TITLE
style: 내 달력, 그룹달력에서 클릭된 날짜는 배경색이 하이라이트 되도록 스타일 추가

### DIFF
--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -25,11 +25,11 @@ interface Props {
   setAvailableDates?: React.Dispatch<React.SetStateAction<string[]>>;
   scheduleData: IScheduleType[] | undefined;
   groupAvailableDates?: IGroupAvailableDatesCalendarItemType[];
+  selectedDate?: string;
   setSelectedDate: React.Dispatch<React.SetStateAction<string>>;
   currentMonth: Date;
   setCurrentMonth: React.Dispatch<React.SetStateAction<Date>>;
-   isEditing?: boolean;
-
+  isEditing?: boolean;
 }
 
 const Calendar: React.FC<Props> = ({
@@ -41,7 +41,8 @@ const Calendar: React.FC<Props> = ({
   setSelectedDate,
   currentMonth,
   setCurrentMonth,
-  isEditing, 
+  isEditing,
+  selectedDate,
 }) => {
   const handlePrevMonth = () => {
     setCurrentMonth((prev) => subMonths(prev, 1));
@@ -102,6 +103,8 @@ const Calendar: React.FC<Props> = ({
         const isAvailable = availableDates?.includes(formattedDate);
         const groupAvailableDate = groupAvailableDates?.find((item) => item.date === formattedDate);
 
+        const isSelected = type === "view" && selectedDate === formattedDate;
+
         let backgroundColor = "transparent";
         if (type === "myPossible" && isAvailable) {
           backgroundColor = "#C9ACE7";
@@ -120,6 +123,10 @@ const Calendar: React.FC<Props> = ({
           backgroundColor = "#F1F3F5";
         }
 
+        if (isSelected) {
+          backgroundColor = "#bdbaba";
+        }
+
         const isHoliday = HOLIDAYS.includes(format(day, "MM-dd"));
         const isSunday = format(day, "i") === "7";
         const isClickable =
@@ -133,9 +140,16 @@ const Calendar: React.FC<Props> = ({
             onClick={() => handleDateClick(formattedDate)}
             style={{
               cursor: isClickable || isGroupClickable || type === "view" ? "pointer" : "default",
-              color: isNotCurrentMonth ? "#767676" : isSunday || isHoliday ? "#FF0101" : "#111111",
+              color: isNotCurrentMonth
+                ? isSelected
+                  ? "var(--white)"
+                  : "#767676"
+                : isSunday || isHoliday
+                  ? "#FF0101"
+                  : "#111111",
               backgroundColor,
-              borderRadius: isToday || isAvailable || groupAvailableDate ? "50%" : "0",
+              borderRadius:
+                isToday || isAvailable || groupAvailableDate || isSelected ? "50%" : "0",
               fontWeight: isToday ? "bold" : "500",
             }}
           >

--- a/src/pages/GroupCalendarPage/page/index.tsx
+++ b/src/pages/GroupCalendarPage/page/index.tsx
@@ -54,6 +54,7 @@ const GroupCalendarPage: React.FC = () => {
           scheduleData={groupCheckEvents?.groupScheduleData}
           currentMonth={currentMonth}
           setCurrentMonth={setCurrentMonth}
+          selectedDate={selectedDate}
           setSelectedDate={setSelectedDate}
         />
       </div>

--- a/src/pages/MyCalendarPage/page/index.tsx
+++ b/src/pages/MyCalendarPage/page/index.tsx
@@ -79,6 +79,7 @@ const MyCalendarPage: React.FC = () => {
             setSelectedDate={setSelectedDate}
             currentMonth={currentMonth}
             setCurrentMonth={setCurrentMonth}
+            selectedDate={selectedDate}
           />
         </div>
         <div className={styles.scheduleSection}>


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #224 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

> - 내 달력, 그룹달력에서 클릭된 날짜는 배경색이 하이라이트 되도록 스타일 추가

## 📝수정 내용(선택)

### 스크린샷 (선택)
<img width="325" alt="스크린샷 2025-04-27 오후 4 48 06" src="https://github.com/user-attachments/assets/d2d2936b-1e25-4920-9bab-2ea74ef956d3" />
<img width="319" alt="스크린샷 2025-04-27 오후 4 48 14" src="https://github.com/user-attachments/assets/2ac6599b-b875-4f14-a278-dc0be61fa022" />

## 💬리뷰 요구사항(선택)
> - 원래 gray-200으로 했는데 달력에 일정 유무 아이콘들이 잘 안보이는 관계로 좀 더 연한 회색으로 수정했고, 이번달이 아닌 날짜들은 클릭되면 글자색이 흰색으로 바뀌도록 수정했습니다.