### PR TITLE
Fix: 채팅관련 ui 수정

### DIFF
--- a/src/pages/ChatListPage/components/ChatItem.tsx
+++ b/src/pages/ChatListPage/components/ChatItem.tsx
@@ -1,8 +1,9 @@
 import ArrowIcon from "@assets/Icons/arrow/RightArrow.svg?react";
 import PinnedIcon from "@assets/Icons/chatt/pinned.svg?react";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styles from "./chatItem.module.scss";
 import { useNavigate } from "react-router-dom";
+import { isSameDay } from "date-fns";
 
 interface ChatItemProps {
   chatRoom: IChatRoomResponseType;
@@ -10,6 +11,17 @@ interface ChatItemProps {
 
 const ChatItem: React.FC<ChatItemProps> = ({ chatRoom }) => {
   const navigate = useNavigate();
+  const [isToday, setIsToday] = useState<boolean>(true);
+
+  useEffect(() => {
+    if (!chatRoom?.lastChatDate) return;
+
+    const chatDate = new Date(chatRoom.lastChatDate);
+    const today = new Date();
+
+    const isToday = isSameDay(chatDate, today);
+    setIsToday(isToday);
+  }, [chatRoom.lastChatDate]);
 
   const handleChatRoomClick = () => {
     navigate(`/group/${chatRoom.groupId}/chatting`);
@@ -28,11 +40,19 @@ const ChatItem: React.FC<ChatItemProps> = ({ chatRoom }) => {
             {chatRoom.groupName}
             {chatRoom.isPin && <PinnedIcon className={styles.pinnedIcon} />}
           </div>
-          <div className={styles.lastMessage}>{chatRoom.lastChat}</div>
+          <div className={styles.lastMessage}>
+            {chatRoom.lastChat.includes(
+              "https://planu-storage-main.s3.ap-northeast-2.amazonaws.com",
+            )
+              ? "사진을 보냈습니다."
+              : chatRoom.lastChat}
+          </div>
         </div>
         <div className={styles.timeInfo}>
           <div className={styles.topBox}>
-            <span className={styles.time}>{chatRoom.lastChatTime}</span>
+            <span className={styles.time}>
+              {isToday ? chatRoom.lastChatTime : chatRoom.lastChatDate}
+            </span>
             <ArrowIcon className={styles.arrowIcon} />
           </div>
           {chatRoom.unreadChats > 0 ? (

--- a/src/pages/ChatListPage/components/chatItem.module.scss
+++ b/src/pages/ChatListPage/components/chatItem.module.scss
@@ -50,8 +50,8 @@
   color: var(--gray-200);
   margin-top: 9px;
   display: -webkit-box;
-  line-clamp: 2;
-  -webkit-line-clamp: 2;
+  line-clamp: 1;
+  -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/pages/ChattingPage/components/ChatBubble.tsx
+++ b/src/pages/ChattingPage/components/ChatBubble.tsx
@@ -29,14 +29,12 @@ const ChatBubble: React.FC<Props> = ({ message, isSentByMe, type }) => {
       <div className={styles.MiddleContainer}>
         <div className={styles.bubble}>
           {type === 1 && (
-            <p className={`${isSentByMe ? styles.sentText : styles.receivedText}`}>
-              {message.message}
-            </p>
+            <p className={`${isSentByMe ? styles.sent : styles.received}`}>{message.message}</p>
           )}
           {type === 2 && (
             <img
               src={message.message}
-              className={`${styles.image} ${isSentByMe ? styles.sentText : styles.receivedText}`}
+              className={`${styles.image} ${isSentByMe ? styles.sent : styles.received}`}
             />
           )}
         </div>

--- a/src/pages/ChattingPage/components/chatBubble.module.scss
+++ b/src/pages/ChattingPage/components/chatBubble.module.scss
@@ -36,6 +36,7 @@
 .bubble {
   padding: 6px 12px;
   border-radius: 10px;
+  user-select: text;
 
   .image {
     width: 100%;
@@ -44,6 +45,7 @@
 
 .sent {
   justify-content: flex-end;
+  user-select: text;
 
   .bubble {
     background-color: var(--violet-50);
@@ -54,6 +56,7 @@
 
 .received {
   justify-content: flex-start;
+  user-select: text;
 
   .bubble {
     background-color: var(--violet);

--- a/src/pages/ChattingPage/components/chatBubble.module.scss
+++ b/src/pages/ChattingPage/components/chatBubble.module.scss
@@ -1,6 +1,5 @@
 .bubbleContainer {
   display: flex;
-  align-items: end;
   max-width: 100%;
   gap: 5px;
 }
@@ -26,7 +25,9 @@
 .MiddleContainer {
   display: flex;
   flex-direction: column;
+  justify-content: center;
   gap: 3px;
+  max-width: 80%;
 }
 
 .UnreadCount {
@@ -37,6 +38,7 @@
   padding: 6px 12px;
   border-radius: 10px;
   user-select: text;
+  word-break: break-word;
 
   .image {
     width: 100%;
@@ -52,34 +54,34 @@
     border-top-right-radius: 5px;
     align-items: flex-end;
   }
+
+  .MyTimeUnreadCountBox {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    justify-content: flex-end;
+  }
 }
 
 .received {
-  justify-content: flex-start;
   user-select: text;
+  display: flex;
 
   .bubble {
     background-color: var(--violet);
     border-top-left-radius: 5px;
     align-items: flex-end;
   }
+
+  .TimeUnreadCountBox {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    margin-top: auto;
+  }
 }
 
 .time {
   font-size: 11px;
   color: var(--gray-200);
-}
-
-.MyTimeUnreadCountBox {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-}
-
-.TimeUnreadCountBox {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: end;
-  height: 100%;
 }

--- a/src/pages/ChattingPage/components/sendMessage.module.scss
+++ b/src/pages/ChattingPage/components/sendMessage.module.scss
@@ -4,12 +4,12 @@
   align-items: center;
   position: relative;
   .Input {
-    width: 270px;
+    width: 300px;
     height: 35px;
     border-radius: 30px;
     border: 1.5px solid var(--violet-100);
     font-size: 15px;
-    padding: 0 10px;
+    padding: 0 40px 0 10px;
   }
   .SendIcon {
     position: absolute;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

> 채팅관련 ui 수정

## 📝수정 내용(선택)
-   채팅 목록에서 하루 지난 메세지는 날짜만 뜨도록 하기
-   채팅 박스 너비가 길어져서 시간이 잘리는 문제 해결하기
-  .이나 영어일땐 채팅박스 길이가 화면 넘어가는 문제 해결하기
-  채팅 입력 input 박스에 오른쪽 패딩 전송 버튼크기 만큼 더 주기
-   채팅 목록에서 사진이면 사진을 보냈습니다로 뜨게 수정
-  채팅 메시지에 스타일 속성 user-select: text로 걸어줘서 복사 가능하도록 수정하기

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> - ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
